### PR TITLE
Deis fixes

### DIFF
--- a/server/common.ts
+++ b/server/common.ts
@@ -11,7 +11,8 @@ export const PORT = parseInt(process.env.PORT) || 3000;
 export const STATIC_ROOT = path.resolve(__dirname, "../client");
 export const UPLOAD_ROOT = path.resolve(__dirname, "../uploads"); // Should exist already
 export const VERSION_NUMBER = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../package.json"), "utf8")).version;
-export const VERSION_HASH = process.env.VERSION_HASH || require("git-rev-sync").short();
+export const VERSION_HASH = process.env.SOURCE_VERSION || require("git-rev-sync").short();
+export const {WORKFLOW_RELEASE_CREATED_AT, WORKFLOW_RELEASE_SUMMARY}  = process.env; // Provided by Deis
 export const COOKIE_OPTIONS = {
 	"path": "/",
 	"maxAge": 1000 * 60 * 60 * 24 * 30 * 6, // 6 months


### PR DESCRIPTION
Use Deis' environmental variables and get OAuth callbacks to use the correct port when behind a reverse proxy. OAuth callbacks should still work correctly when not behind a reverse proxy or on a nonstandard HTTP or HTTPS port.