### PR TITLE
Send email to confirm successful application

### DIFF
--- a/client/admin.html
+++ b/client/admin.html
@@ -9,7 +9,7 @@
 		<link rel="stylesheet" href="/node_modules/sweetalert2/dist/sweetalert2.min.css" />
 		<link rel="stylesheet" href="/css/main.css" />
 		<link rel="stylesheet" href="/css/admin.css" />
-		<script src="/js/promise-auto-polyfill.js"></script>
+		<script src="/node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
 		<script src="/node_modules/whatwg-fetch/fetch.js"></script>
 		<script src="/node_modules/sweetalert2/dist/sweetalert2.min.js"></script>
 		<script src="https://use.fontawesome.com/efaca8fe24.js"></script>

--- a/client/application.html
+++ b/client/application.html
@@ -9,7 +9,7 @@
 		<link rel="stylesheet" href="/node_modules/sweetalert2/dist/sweetalert2.min.css" />
 		<link rel="stylesheet" href="/css/main.css" />
 		<link rel="stylesheet" href="/css/application.css" />
-		<script src="/js/promise-auto-polyfill.js"></script>
+		<script src="/node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
 		<script src="/node_modules/whatwg-fetch/fetch.js"></script>
 		<script src="/node_modules/sweetalert2/dist/sweetalert2.min.js"></script>
 		<script src="/js/application.js" defer></script>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "node node_modules/json-schema-to-typescript/dist/cli.js server/config/questions.schema.json && ./node_modules/typescript/bin/tsc -p server/ && ./node_modules/typescript/bin/tsc -p client/",
-    "start": "node server/app.js"
+    "start": "node server/app.js",
+    "build-start": "npm run build && npm start"
   },
   "author": {
     "name": "Ryan Petschek",
@@ -31,6 +32,7 @@
     "connect-flash": "^0.1.1",
     "connect-mongo": "^1.3.2",
     "cookie-parser": "^1.4.3",
+    "es6-promise": "git+https://github.com/stefanpenner/es6-promise.git",
     "express": "^4.14.0",
     "express-session": "^1.15.1",
     "git-rev-sync": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/server/common.ts
+++ b/server/common.ts
@@ -323,3 +323,14 @@ export let emailTransporter = nodemailer.createTransport({
 		pass: config.email.password
 	}
 });
+export async function sendMailAsync(mail: nodemailer.SendMailOptions): Promise<nodemailer.SentMessageInfo>  {
+	return new Promise<nodemailer.SentMessageInfo>((resolve, reject) => {
+		emailTransporter.sendMail(mail, (err, info) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+			resolve(info);
+		});
+	});
+}

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -5,6 +5,7 @@ import * as express from "express";
 import {
 	UPLOAD_ROOT,
     postParser, uploadHandler,
+	config, sendMailAsync,
 	validateSchema
 } from "../../common";
 import {
@@ -126,6 +127,39 @@ userRoutes.post("/application/:branch", isUserOrAdmin, postParser, uploadHandler
 			}
 			return item;
 		});
+		// Email the applicant to confirm
+		// TODO: Make the content of these emails admin-configurable
+		let text: string;
+		if (questionBranch.name.toLowerCase() === "mentor") {
+			text =
+`Hi!
+
+Thank you for singing up to be a mentor at ${config.eventName}. For background check forms, please send us these forms (https://drive.google.com/open?id=0B8MqIMxG0xUJcmU5RFppWUNhWUE) completed as soon as possible -- they must be processed and confirmed prior to the event. Once we receive the forms, you will receive a link to sign up for a training session. If you have any questions, please don't hesitate to reply to this email.
+
+Sincerely,
+
+The ${config.eventName} Team`;
+		}
+		else {
+			text =
+`Hi!
+
+Thank you for applying to be a ${questionBranch.name} at ${config.eventName}! Feel free to go back and update your application any time before registration closes.
+
+If you have any questions please don't hesitate to contact us by replying to this email.
+
+Sincerely,
+
+The ${config.eventName} Team`;
+		}
+		if (!user.applied) {
+			await sendMailAsync({
+				from: config.email.from,
+				to: user.email,
+				subject: `[${config.eventName}] - Thank you for appying!`,
+				text: text // TODO: Add HTML email template
+			});
+		}
 
 		user.applied = true;
 		user.applicationBranch = questionBranch.name;

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -134,7 +134,7 @@ userRoutes.post("/application/:branch", isUserOrAdmin, postParser, uploadHandler
 			text =
 `Hi!
 
-Thank you for singing up to be a mentor at ${config.eventName}. For background check forms, please send us these forms (https://drive.google.com/open?id=0B8MqIMxG0xUJcmU5RFppWUNhWUE) completed as soon as possible -- they must be processed and confirmed prior to the event. Once we receive the forms, you will receive a link to sign up for a training session. If you have any questions, please don't hesitate to reply to this email.
+Thank you for singing up to be a mentor at ${config.eventName}. Please send us these completed background check forms (https://drive.google.com/open?id=0B8MqIMxG0xUJcmU5RFppWUNhWUE) as soon as possible. Once we receive the forms, you will receive a link to sign up for a training session. If you have any questions, please don't hesitate to contact us by replying to this email.
 
 Sincerely,
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -10,7 +10,7 @@ const MongoStore = connectMongo(session);
 import * as passport from "passport";
 
 import {
-	config, mongoose, PORT, COOKIE_OPTIONS, pbkdf2Async, postParser, emailTransporter
+	config, mongoose, PORT, COOKIE_OPTIONS, pbkdf2Async, postParser, sendMailAsync
 } from "../common";
 import {
 	IUser, IUserMongoose, User
@@ -217,19 +217,22 @@ passport.use(new LocalStrategy({
 
 Thanks for signing up for ${config.eventName}! To verify your email, please click the following link: ${link}
 
-Thanks, The ${config.eventName} Team.`
-		emailTransporter.sendMail({
-			from: config.email.from,
-			to: email,
-			subject: `[${config.eventName}] - Verify your email`,
-			text: text // TODO: Add HTML email template
-		}, (err, info) => {
-			if (err) {
-				done(err);
-				return;
-			}
-			done(null, user);
-		});
+Sincerely,
+
+The ${config.eventName} Team.`;
+		try {
+			await sendMailAsync({
+				from: config.email.from,
+				to: email,
+				subject: `[${config.eventName}] - Verify your email`,
+				text: text // TODO: Add HTML email template
+			});
+		}
+		catch (err) {
+			done(err);
+			return;
+		}
+		done(null, user);
 	}
 	else {
 		// Log the user in


### PR DESCRIPTION
- [x] Sends a general confirmation email to participants and chaperones who have applied.
- [x] Sends an email containing required actions for mentors for the HackGT Catalyst event
- [x] Fixes a bug where the ES6 Promises polyfill wasn't being loaded correctly.

**TODO:** Allow admins to configure email content in the admin panel

Closes #50 