### PR TITLE
Support application closing times

### DIFF
--- a/client/closed.html
+++ b/client/closed.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>Application Closed - {{siteTitle}}</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+		<link rel="stylesheet" href="/css/wing-0.1.9.min.css" />
+		<link rel="stylesheet" href="/css/main.css" />
+	</head>
+	<body>
+		{{#> sidebar}}
+			<h1 class="center">Application Closed</h1>
+				
+			<p>Sorry, applications are currently closed.</p>
+			<p>Applications {{open.verb}} on {{open.time}} and {{close.verb}} on {{close.time}}.</p>
+			<p>If you have any questions, please email the {{siteTitle}} team at <a href="mailto:{{contactEmail}}">{{contactEmail}}</a>.</p>
+		{{/sidebar}}
+	</body>
+</html>

--- a/client/index.html
+++ b/client/index.html
@@ -40,12 +40,25 @@
 						<p></p>
 					{{else if user.applied}}
 						<p>You've applied to be a <b>{{user.applicationBranch}}</b>!</p>
-						<p>Feel free to edit your application at any time. However, once registration closes on {{applicationClose}}, you will not be able to edit it any further.</p>
-						<a class="btn" href="/apply">Edit your application</a>
+						{{#if applicationStatus.areOpen}}
+							<p>Feel free to edit your application at any time. However, once registration closes on {{applicationClose}}, you will not be able to edit it any further.</p>
+							<a class="btn" href="/apply">Edit your application</a>
+						{{else}}
+							<p>Applications closed on {{applicationClose}}.</p>
+						{{/if}}
 					{{else}}
-						<p>You still need to complete your application!</p>
-						<p>If you do not complete your application before {{applicationClose}}, you will not be considered for {{siteTitle}}!</p>
-						<a class="btn" href="/apply">Complete your application</a>
+						{{#if applicationStatus.areOpen}}
+							<p>You still need to complete your application!</p>
+							<p>If you do not complete your application before {{applicationClose}}, you will not be considered for {{siteTitle}}!</p>
+							<a class="btn" href="/apply">Complete your application</a>
+						{{else}}
+							{{#if applicationStatus.beforeOpen}}
+								<p>Applications are currently closed and will open on {{applicationOpen}}.</p>
+							{{/if}}
+							{{#if applicationStatus.afterClose}}
+								<p>Applications closed on {{applicationClose}}. Unfortunately, because you did not submit an application, you will not be eligible for {{siteTitle}}.</p>
+							{{/if}}
+						{{/if}}
 					{{/if}}
 				</div>
 			</section>

--- a/client/unsupported.html
+++ b/client/unsupported.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>Unsupported Browser | {{siteTitle}}</title>
+		<title>Unsupported Browser - {{siteTitle}}</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -9,6 +9,7 @@ import {
 	STATIC_ROOT,
 	authenticateWithReject,
 	authenticateWithRedirect,
+	timeLimited,
 	validateSchema, config
 } from "../common";
 import {
@@ -116,7 +117,7 @@ templateRoutes.route("/login").get((request, response) => {
 	response.send(loginTemplate(templateData));
 });
 
-templateRoutes.route("/apply").get(authenticateWithRedirect, async (request, response) => {
+templateRoutes.route("/apply").get(authenticateWithRedirect, timeLimited, async (request, response) => {
 	let user = request.user as IUser;
 	if (user.applied) {
 		response.redirect(`/apply/${encodeURIComponent(user.applicationBranch.toLowerCase())}`);
@@ -148,7 +149,7 @@ templateRoutes.route("/apply").get(authenticateWithRedirect, async (request, res
 	};
 	response.send(preregisterTemplate(templateData));
 });
-templateRoutes.route("/apply/:branch").get(authenticateWithRedirect, async (request, response) => {
+templateRoutes.route("/apply/:branch").get(authenticateWithRedirect, timeLimited, async (request, response) => {
 	let user = request.user as IUser;
 	let branchName = request.params.branch as string;
 	if (user.applied && branchName.toLowerCase() !== user.applicationBranch.toLowerCase()) {

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -151,7 +151,13 @@ export interface ICommonTemplate {
 	};
 }
 export interface IIndexTemplate extends ICommonTemplate {
+	applicationOpen: string;
 	applicationClose: string;
+	applicationStatus: {
+		areOpen: boolean;
+		beforeOpen: boolean;
+		afterClose: boolean;
+	};
 }
 export interface ILoginTemplate {
 	siteTitle: string;


### PR DESCRIPTION
Adds the necessary code to the dashboard and to the `/apply` routes to only work when applications are open as configured in the admin panel. This ability is implemented as a reusable Express middleware function so that we can easily use it for routes that we add in the future as well.

**We need this to go live before HackGT Catalyst applications close tonight (4/9/17)**