### PR TITLE
Add basic, preliminary CSV export to use with Ultimate-Checkin

### DIFF
--- a/client/admin.html
+++ b/client/admin.html
@@ -129,6 +129,9 @@
 			</section>
 			<section id="applicants">
 				<h2>Applicants</h2>
+				<div class="center">
+					<a href="/api/user/all/export" class="btn">Export for check in</a>
+				</div>
 				<table>
 					<thead>
 						<th>Name</th>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {
@@ -38,6 +38,7 @@
     "git-rev-sync": "^1.8.0",
     "handlebars": "^4.0.6",
     "json-schema-to-typescript": "^3.1.3",
+    "json2csv": "^3.7.3",
     "moment-timezone": "^0.5.11",
     "mongoose": "^4.9.1",
     "morgan": "^1.8.1",
@@ -78,6 +79,6 @@
     "chai": "^3.5.0",
     "mocha": "^3.2.0",
     "supertest": "^3.0.0",
-    "typescript": "^2.2.1"
+    "typescript": "^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "private": true,
   "dependencies": {
     "ajv": "^4.11.5",
+    "archiver": "^1.3.0",
     "body-parser": "^1.17.1",
     "bowser": "^1.6.0",
     "compression": "^1.6.2",
@@ -54,6 +55,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
+    "@types/archiver": "^0.15.37",
     "@types/body-parser": "1.16.0",
     "@types/chai": "^3.4.35",
     "@types/compression": "0.0.33",

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as express from "express";
 import * as json2csv from "json2csv";
+import * as archiver from "archiver";
 
 import {
 	UPLOAD_ROOT,
@@ -254,21 +255,42 @@ userRoutes.route("/status").post(isAdmin, uploadHandler.any(), async (request, r
 
 userRoutes.route("/export").get(isAdmin, async (request, response) => {
 	try {
-		// TODO: THIS IS A PRELIMINARY VERSION FOR HACKGT CATALYST
-		// TODO: Change this to { "accepted": true }
-		let attendingUsers: IUserMongoose[] = await User.find({ "applied": true });
-		let csvData = attendingUsers.map(user => {
-			// TODO: Replace with more robust schema-agnostic version
-			let nameFormItem = user.applicationData.find(item => item.name === "name");
-			return {
-				"name": nameFormItem && typeof nameFormItem.value === "string" ? nameFormItem.value : user.name,
-				"email": user.email
-			};
-		});
+		let questionBranches: QuestionBranches;
+		try {
+			questionBranches = await validateSchema("./config/questions.json", "./config/questions.schema.json");
+		}
+		catch (err) {
+			console.error("validateSchema error:", err);
+			response.status(500).json({
+				"error": "An error occurred while validating question structure"
+			});
+			return;
+		}
 
-		response.status(200).type("text/csv").attachment("export.csv");
-		response.write(json2csv({ data: csvData, fields: Object.keys(csvData[0]) }));
-		response.end();
+		let branchNames: string[] = questionBranches.map(branch => branch.name);
+		let archive = archiver("zip", {
+			store: true
+		});
+		response.status(200).type("application/zip");
+		archive.pipe(response);
+		
+		for (let branchName of branchNames) {
+			// TODO: THIS IS A PRELIMINARY VERSION FOR HACKGT CATALYST
+			// TODO: Change this to { "accepted": true }
+			let attendingUsers: IUserMongoose[] = await User.find({ "applied": true, "applicationBranch": branchName });
+			if (attendingUsers.length === 0) continue;
+
+			let csvData = attendingUsers.map(user => {
+				// TODO: Replace with more robust schema-agnostic version
+				let nameFormItem = user.applicationData.find(item => item.name === "name");
+				return {
+					"name": nameFormItem && typeof nameFormItem.value === "string" ? nameFormItem.value : user.name,
+					"email": user.email
+				};
+			});
+			archive.append(json2csv({ data: csvData, fields: Object.keys(csvData[0]) }), { "name": branchName + ".csv" });
+		}
+		archive.finalize();
 	}
 	catch (err) {
 		console.error(err);


### PR DESCRIPTION
A simple, stopgap solution for how to better integrate the registration and check in projects for HackGT Catalyst.

When importing from check in, use `name` and `email` as the name and email fields respectively instead of the defaults.