### PR TITLE
Add support for text blocks that can be attached to questions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && apk add bash
 RUN apk add git
 # Install latest npm version (in case Node.js hasn't updated with the newest version yet)
 # npm install -g npm@latest doesn't work -> see https://github.com/npm/npm/issues/15611#issuecomment-289133810 for this hack
-RUN npm install npm@"~5.1.0" && rm -rf /usr/local/lib/node_modules && mv node_modules /usr/local/lib
+RUN npm install npm@"~5.2.0" && rm -rf /usr/local/lib/node_modules && mv node_modules /usr/local/lib
 
 # Bundle app source
 WORKDIR /usr/src/registration

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && apk add bash
 RUN apk add git
 # Install latest npm version (in case Node.js hasn't updated with the newest version yet)
 # npm install -g npm@latest doesn't work -> see https://github.com/npm/npm/issues/15611#issuecomment-289133810 for this hack
-RUN npm install npm@latest && rm -rf /usr/local/lib/node_modules && mv node_modules /usr/local/lib
+RUN npm install npm@"~5.1.0" && rm -rf /usr/local/lib/node_modules && mv node_modules /usr/local/lib
 
 # Bundle app source
 WORKDIR /usr/src/registration

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,13 @@ MAINTAINER Ryan Petschek <petschekr@gmail.com>
 # Deis wants bash
 RUN apk update && apk add bash
 RUN apk add git
+# Install latest npm version (in case Node.js hasn't updated with the newest version yet)
+# npm install -g npm@latest doesn't work -> see https://github.com/npm/npm/issues/15611#issuecomment-289133810 for this hack
+RUN npm install npm@latest && rm -rf /usr/local/lib/node_modules && mv node_modules /usr/local/lib
 
 # Bundle app source
-WORKDIR /usr/src/checkin
-COPY . /usr/src/checkin
+WORKDIR /usr/src/registration
+COPY . /usr/src/registration
 RUN npm install
 RUN npm run build
 

--- a/client/application.html
+++ b/client/application.html
@@ -65,6 +65,7 @@
 					{{/if}}
 					<br />
 				{{/each}}
+				{{{endText}}}
 				<div class="center">
 					{{#if user.applied}}
 						<input type="submit" value="Update" />

--- a/client/application.html
+++ b/client/application.html
@@ -25,6 +25,9 @@
 			-->
 			<form method="post" data-action="/api/user/{{user._id}}/application/{{slug branch}}">
 				{{#each questionData}}
+					{{#if this.textContent}}
+						{{{this.textContent}}}
+					{{/if}}
 					{{#if this.multi}}
 						{{#ifCond this.type "select"}}
 							<label for="form-{{this.name}}">{{this.label}}</label>

--- a/client/confirmation.html
+++ b/client/confirmation.html
@@ -65,6 +65,7 @@
 					{{/if}}
 					<br />
 				{{/each}}
+				{{{endText}}}
 				<div class="center">
 					{{#if user.attending}}
 						<input type="submit" value="Update" />

--- a/client/confirmation.html
+++ b/client/confirmation.html
@@ -25,6 +25,9 @@
 			-->
 			<form method="post" data-action="/api/user/{{user._id}}/confirmation/{{slug branch}}">
 				{{#each questionData}}
+					{{#if this.textContent}}
+						{{{this.textContent}}}
+					{{/if}}
 					{{#if this.multi}}
 						{{#ifCond this.type "select"}}
 							<label for="form-{{this.name}}">{{this.label}}</label>

--- a/client/css/admin.css
+++ b/client/css/admin.css
@@ -126,3 +126,7 @@ rect.bar:hover {
     }
 
 }
+
+.branch-role:nth-of-type(3n + 1) {
+    margin-left: 0;
+}

--- a/client/css/application.css
+++ b/client/css/application.css
@@ -31,8 +31,16 @@ input:not([type=submit]):not([type=radio]):not([type=checkbox]):not([type=reset]
     outline: none;
     font-family: 'Open Sans';
 }
+form > h1,
+form > h2,
+form > h3,
+form > h4,
+form > h5,
+form > h6 {
+    text-align: center;
+}
 form > p {
-    font-family: "Quicksand";    
+    font-family: "Quicksand";
 }
 fieldset {
 	padding: 8px 20px;

--- a/client/css/application.css
+++ b/client/css/application.css
@@ -13,7 +13,7 @@ label {
     line-height: 1.5;
     letter-spacing: 0;
     font-weight: 300;
-    font-family: Quicksand;
+    font-family: "Quicksand";
 }
 /* Extend Wing's input styles to cover additional types
  * See https://github.com/KingPixil/wing/issues/8
@@ -30,6 +30,9 @@ input:not([type=submit]):not([type=radio]):not([type=checkbox]):not([type=reset]
     transition: 0.5s;
     outline: none;
     font-family: 'Open Sans';
+}
+form > p {
+    font-family: "Quicksand";    
 }
 fieldset {
 	padding: 8px 20px;

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -292,11 +292,16 @@ settingsUpdateButton.addEventListener("click", e => {
 			body: branchRoleData
 		});
 	}).then(checkStatus).then(parseJSON).then(() => {
-		return fetch(`/api/settings/email_content/${emailTypeSelect.value}`, {
-			...defaultOptions,
-			body: emailContentData
-		});
-	}).then(checkStatus).then(parseJSON).then(async () => {
+		if (emailTypeSelect.value) {
+			return fetch(`/api/settings/email_content/${emailTypeSelect.value}`, {
+				...defaultOptions,
+				body: emailContentData
+			}).then(checkStatus).then(parseJSON);
+		}
+		else {
+			return Promise.resolve();
+		}
+	}).then(async () => {
 		await sweetAlert("Awesome!", "Settings successfully updated.", "success");
 		window.location.reload();
 	}).catch(async (err: Error) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,81 +1,127 @@
 {
   "name": "registration",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/archiver": {
-      "version": "https://registry.npmjs.org/@types/archiver/-/archiver-0.15.37.tgz",
+      "version": "0.15.37",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-0.15.37.tgz",
       "integrity": "sha1-5cgLrWyaiY/AlK6UWy3DITx47A4=",
-      "dev": true
-    },
-    "@types/bluebird": {
-      "version": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha1-PH6M9mC51g6iXHh/3SWN22q7OE0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.8"
+      }
     },
     "@types/body-parser": {
-      "version": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.0.tgz",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.0.tgz",
       "integrity": "sha1-mOndlmSn+oFP7CxQyVu/ntrPXwU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36",
+        "@types/node": "8.0.8"
+      }
     },
     "@types/bson": {
-      "version": "https://registry.npmjs.org/@types/bson/-/bson-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-1.0.3.tgz",
       "integrity": "sha1-bCbwh2v52Muwbt1AGeKTVL86A+A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.8"
+      }
     },
     "@types/chai": {
-      "version": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
       "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
       "dev": true
     },
     "@types/compression": {
-      "version": "https://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
       "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36"
+      }
     },
     "@types/connect-flash": {
-      "version": "https://registry.npmjs.org/@types/connect-flash/-/connect-flash-0.0.31.tgz",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@types/connect-flash/-/connect-flash-0.0.31.tgz",
       "integrity": "sha1-hrjj2tEwfi0QXYNopxO/kPjLwFo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36"
+      }
     },
     "@types/connect-mongo": {
-      "version": "https://registry.npmjs.org/@types/connect-mongo/-/connect-mongo-0.0.32.tgz",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/connect-mongo/-/connect-mongo-0.0.32.tgz",
       "integrity": "sha1-k5ynCFE0gsfT8yo4xjfUnSrH0JA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36",
+        "@types/express-session": "0.0.32",
+        "@types/mongodb": "2.2.7",
+        "@types/mongoose": "4.7.18"
+      }
     },
     "@types/cookie-parser": {
-      "version": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.3.30.tgz",
+      "version": "1.3.30",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.3.30.tgz",
       "integrity": "sha1-cOSCQIbi8hTbxnT9ki0cJ0RHU5I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36"
+      }
     },
     "@types/core-js": {
-      "version": "https://registry.npmjs.org/@types/core-js/-/core-js-0.9.41.tgz",
-      "integrity": "sha1-z+zrY8K+qin4giUsfBjg6Ucf9OI=",
+      "version": "0.9.42",
+      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-0.9.42.tgz",
+      "integrity": "sha512-AiEZz42jF2f4nkcJ2OhKWxIbXU62pEHmFoaGoGo83seUzDEncxEZtBPX2i2DLUpcVpaVVxAsqAAZzTyrV0A/RQ==",
       "dev": true
     },
     "@types/d3": {
-      "version": "https://registry.npmjs.org/@types/d3/-/d3-3.5.38.tgz",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-3.5.38.tgz",
       "integrity": "sha1-dvjy6RWa5WKWWy+g5vvuGqZDobw=",
       "dev": true
     },
     "@types/express": {
-      "version": "https://registry.npmjs.org/@types/express/-/express-4.0.36.tgz",
-      "integrity": "sha1-FOtH3n7LEDGfCi+xz5caqGgHWMI=",
-      "dev": true
+      "version": "4.0.36",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.36.tgz",
+      "integrity": "sha512-bT9q2eqH/E72AGBQKT50dh6AXzheTqigGZ1GwDiwmx7vfHff0bZOrvUWjvGpNWPNkRmX1vDF6wonG6rlpBHb1A==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "4.0.49",
+        "@types/serve-static": "1.7.31"
+      }
     },
     "@types/express-serve-static-core": {
-      "version": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.47.tgz",
-      "integrity": "sha1-cbPGsGC6iuqX0gUXH/Pzpp09tGU=",
-      "dev": true
+      "version": "4.0.49",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.49.tgz",
+      "integrity": "sha512-b7mVHoURu1xaP/V6xw1sYwyv9V0EZ7euyi+sdnbnTZxEkAh4/hzPsI6Eflq+ZzHQ/Tgl7l16Jz+0oz8F46MLnA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.8"
+      }
     },
     "@types/express-session": {
-      "version": "https://registry.npmjs.org/@types/express-session/-/express-session-0.0.32.tgz",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-0.0.32.tgz",
       "integrity": "sha1-gvnmoCjrYSWkEtuV8OYal9GUXuA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36",
+        "@types/node": "8.0.8"
+      }
     },
     "@types/handlebars": {
-      "version": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.33.tgz",
-      "integrity": "sha1-7kVpawZ+S98Vw5VnEKTDbBfY+PA=",
+      "version": "4.0.33",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.33.tgz",
+      "integrity": "sha512-39w19Mseg83z68JsIdcuFH3Z+BR/Jc3gRBB4Pn/aUm76rdy0prMz5iIMJAOb0Bo6H/rZhQc41vFf3tAMgqufVQ==",
       "dev": true
     },
     "@types/marked": {
@@ -85,12 +131,14 @@
       "dev": true
     },
     "@types/mime": {
-      "version": "https://registry.npmjs.org/@types/mime/-/mime-1.3.0.tgz",
-      "integrity": "sha1-0k/6x9EAb+aFFyAvsq66Pb5IKEs=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.1.tgz",
+      "integrity": "sha512-rek8twk9C58gHYqIrUlJsx8NQMhlxqHzln9Z9ODqiNgv3/s+ZwIrfr+djqzsnVM12xe9hL98iJ20lj2RvCBv6A==",
       "dev": true
     },
     "@types/mocha": {
-      "version": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.41.tgz",
+      "version": "2.2.41",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.41.tgz",
       "integrity": "sha1-4nzwgXFT658nE7LT9saPHhw8pgg=",
       "dev": true
     },
@@ -98,783 +146,1357 @@
       "version": "0.2.34",
       "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.2.34.tgz",
       "integrity": "sha1-lI4K/4J0KjHdY3FNGqyWFrw3UFM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "moment": "2.18.1"
+      }
     },
     "@types/mongodb": {
-      "version": "https://registry.npmjs.org/@types/mongodb/-/mongodb-2.2.5.tgz",
-      "integrity": "sha1-cfdYVF0tLDPOJnT8xXfVHPA7IWs=",
-      "dev": true
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-2.2.7.tgz",
+      "integrity": "sha512-ckuHaelFeqjytOQWbjcHOHmB8bjnHAiJwJssPT23IohF5UO+nDHS8Bgfdyk7cvVSVRD9wmEiGt41nec0FRYBSQ==",
+      "dev": true,
+      "requires": {
+        "@types/bson": "1.0.3",
+        "@types/node": "8.0.8"
+      }
     },
     "@types/mongoose": {
-      "version": "https://registry.npmjs.org/@types/mongoose/-/mongoose-4.7.17.tgz",
-      "integrity": "sha1-IbrDzGX8TqtRhX/02ap25MK5PK4=",
-      "dev": true
+      "version": "4.7.18",
+      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-4.7.18.tgz",
+      "integrity": "sha512-DNgUKoVygZtUieTZ4Fc5ZdgVQr/exkzF1MRYnciimFSsZCDjRkdpjZ1altm9e/IpInUjb37nRwhkTBeX6RDULg==",
+      "dev": true,
+      "requires": {
+        "@types/mongodb": "2.2.7",
+        "@types/node": "8.0.8"
+      }
     },
     "@types/morgan": {
-      "version": "https://registry.npmjs.org/@types/morgan/-/morgan-1.7.32.tgz",
+      "version": "1.7.32",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.7.32.tgz",
       "integrity": "sha1-+rHs5NrhcuGjd9Vj0z42NPoEkn0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36"
+      }
     },
     "@types/multer": {
-      "version": "https://registry.npmjs.org/@types/multer/-/multer-0.0.33.tgz",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-0.0.33.tgz",
       "integrity": "sha1-B1bfH1Je2O82ndHybdg0W9ZGcEA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36"
+      }
     },
     "@types/node": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.28.tgz",
-      "integrity": "sha512-9rLhvgupMpC7Yh24yB8zj+4L6SZ9BYUwqknEC8+R7gqCg3KL65UHg7yu9X6J8mSmmtVr1Hbey564yZ3C9nXqtQ==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.8.tgz",
+      "integrity": "sha512-mDdL8leJCDIe2uSA+jp2quT6t7y0Pt9guPYzfoMt97r8dhRGZ+jLetPYHCCHXLnWdmae/zHZIYvzTQaTj6BCQg==",
       "dev": true
     },
     "@types/nodemailer": {
-      "version": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-1.3.32.tgz",
-      "integrity": "sha1-djiKqTiakpBBbJjq/X0k2A76IzM=",
-      "dev": true
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-1.3.33.tgz",
+      "integrity": "sha512-PONEJf/LwNcqgU/GpMIAquSBFdq+kCdpYI9TdoeGcTfLCsXzWunKzv4bUQs8zfKGz97CLymgoL0fMLYpOu+/1A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.8",
+        "@types/nodemailer-direct-transport": "1.0.29",
+        "@types/nodemailer-smtp-transport": "2.7.2"
+      }
     },
     "@types/nodemailer-direct-transport": {
-      "version": "https://registry.npmjs.org/@types/nodemailer-direct-transport/-/nodemailer-direct-transport-1.0.29.tgz",
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer-direct-transport/-/nodemailer-direct-transport-1.0.29.tgz",
       "integrity": "sha1-Ake7RzT4u/k5gkGxa0ECLhMD3fE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/nodemailer": "1.3.33"
+      }
     },
     "@types/nodemailer-smtp-transport": {
-      "version": "https://registry.npmjs.org/@types/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.1.tgz",
-      "integrity": "sha1-+acVZXRUfG1G5t910QMXlmDnqbA=",
-      "dev": true
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.2.tgz",
+      "integrity": "sha512-sFeTdk87Xk4ADTs7HY32Thr/sD06HJHPbmjuCOGtqVhSnMeVPf3OQAU3d4oW9bhccRLpjCWUds00CrbuU/iLzw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.8",
+        "@types/nodemailer": "1.3.33"
+      }
     },
     "@types/passport": {
-      "version": "https://registry.npmjs.org/@types/passport/-/passport-0.3.3.tgz",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-0.3.3.tgz",
       "integrity": "sha1-RjRVxCRe0jLWzkNhVYDBABregjQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36"
+      }
     },
     "@types/passport-facebook": {
-      "version": "https://registry.npmjs.org/@types/passport-facebook/-/passport-facebook-2.1.4.tgz",
-      "integrity": "sha1-lwlPgNfmSvKe7Ow1nEowefvdE5M=",
-      "dev": true
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/passport-facebook/-/passport-facebook-2.1.5.tgz",
+      "integrity": "sha512-WFNO1nim5vzCj0kBuBR+IYIU7xqY0QppiPIfK6ix0qVGxk2JeQmRRJAvWtaIt3wAMGzXdZq9RjCA9Hveergi/Q==",
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36",
+        "@types/passport": "0.3.3"
+      }
     },
     "@types/passport-local": {
-      "version": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.30.tgz",
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.30.tgz",
       "integrity": "sha1-8REgHw2DNjjlqBiZFyFWlm/3w1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.36",
+        "@types/passport": "0.3.3"
+      }
     },
     "@types/serve-static": {
-      "version": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.31.tgz",
+      "version": "1.7.31",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.31.tgz",
       "integrity": "sha1-FUVt6NmNa0z/Mb5savdJKuY/Uho=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "4.0.49",
+        "@types/mime": "1.3.1"
+      }
     },
     "@types/superagent": {
-      "version": "https://registry.npmjs.org/@types/superagent/-/superagent-3.5.0.tgz",
-      "integrity": "sha1-U5NcVkYWmYskhGwOYMeSwP2CczQ=",
-      "dev": true
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.5.2.tgz",
+      "integrity": "sha512-msNAamo2ZmF68Il1BBMoArr5cG2Km9M0jPsTzUUaKGXxrI9rT/xVi0hVdVWjHy86sEoVXjaf5Gvx4Ptwai2laA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.8"
+      }
     },
     "@types/supertest": {
-      "version": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.1.tgz",
-      "integrity": "sha1-ZujYSidK1Lu+uX13Mp5T2QuC8RI=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.1.tgz",
+      "integrity": "sha512-Bbb6TuZ5SNlsQ/M4EbbQRA6+wu7oQuCBVFuFu7/rV/bTTyCjCoBd0Qldr/YLBc1YYhI6JghT0wG+LuPIOIzxLA==",
+      "dev": true,
+      "requires": {
+        "@types/superagent": "3.5.2"
+      }
     },
     "@types/whatwg-fetch": {
-      "version": "https://registry.npmjs.org/@types/whatwg-fetch/-/whatwg-fetch-0.0.33.tgz",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-fetch/-/whatwg-fetch-0.0.33.tgz",
       "integrity": "sha1-GcDShjyMsjgPIaHHNrecv3iVuxM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/whatwg-streams": "0.0.3"
+      }
     },
     "@types/whatwg-streams": {
-      "version": "https://registry.npmjs.org/@types/whatwg-streams/-/whatwg-streams-0.0.3.tgz",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-streams/-/whatwg-streams-0.0.3.tgz",
       "integrity": "sha1-SFPYafPibVrf0NlAe27c5xbQa/4=",
       "dev": true
     },
     "accepts": {
-      "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "requires": {
+        "mime-types": "2.1.15",
+        "negotiator": "0.6.1"
+      }
     },
     "ajv": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.6.tgz",
-      "integrity": "sha1-Sy8aGd7Ok9V6whYDfj6XkcfdFWQ="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
+      "integrity": "sha1-wXNQJMXaLvdcwZBxMHPUTwmL9IY=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "0.1.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "align-text": {
-      "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
-      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-regex": {
-      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
-      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "any-promise": {
-      "version": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "append-field": {
-      "version": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
       "integrity": "sha1-bdxY+gg8e8VF08WZWygwzCNm1Eo="
     },
     "archiver": {
-      "version": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
-      "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+      "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "async": "2.5.0",
+        "buffer-crc32": "0.2.13",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.3",
+        "tar-stream": "1.5.4",
+        "walkdir": "0.0.11",
+        "zip-stream": "1.2.0"
+      }
     },
     "archiver-utils": {
-      "version": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.4",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
+      }
     },
     "argparse": {
-      "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-flatten": {
-      "version": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "assertion-error": {
-      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "async": {
-      "version": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-      "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "asynckit": {
-      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "babel-code-frame": {
-      "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
     },
     "balanced-match": {
-      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "basic-auth": {
-      "version": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ="
     },
     "bl": {
-      "version": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
     },
     "bluebird": {
-      "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
     },
     "body-parser": {
-      "version": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
-      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4="
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
+      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
+      "requires": {
+        "bytes": "2.4.0",
+        "content-type": "1.0.2",
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "http-errors": "1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "2.3.0",
+        "qs": "6.4.0",
+        "raw-body": "2.2.0",
+        "type-is": "1.6.15"
+      }
     },
     "bowser": {
-      "version": "https://registry.npmjs.org/bowser/-/bowser-1.7.0.tgz",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.7.0.tgz",
       "integrity": "sha1-Fp3kAYcR+ZQkK/+agAnneh814AM="
     },
     "brace-expansion": {
-      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
-      "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
     "bson": {
-      "version": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
       "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
     },
     "buffer-crc32": {
-      "version": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-shims": {
-      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "busboy": {
-      "version": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.14"
+      },
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "bytes": {
-      "version": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
       "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
     },
     "call-me-maybe": {
-      "version": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "camelcase": {
-      "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "optional": true
     },
     "center-align": {
-      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chai": {
-      "version": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
       "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "2.0.2",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.3"
+      }
     },
     "chalk": {
-      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
       "dependencies": {
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "check-error": {
-      "version": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "cli-color": {
-      "version": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
-      "integrity": "sha1-OlrnT9drYmevZm5p4q+70B3vNNE="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
+      "integrity": "sha1-OlrnT9drYmevZm5p4q+70B3vNNE=",
+      "requires": {
+        "ansi-regex": "2.1.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "memoizee": "0.4.5",
+        "timers-ext": "0.1.2"
+      }
     },
     "cli-table": {
-      "version": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "requires": {
+        "colors": "1.0.3"
+      }
     },
     "cliui": {
-      "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "optional": true
         }
       }
     },
     "co": {
-      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "colors": {
-      "version": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
-      "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "component-emitter": {
-      "version": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
     "compress-commons": {
-      "version": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
-      "integrity": "sha1-WFhwku8g03y1i68AARLJJ4/3O58="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
+      "integrity": "sha1-WFhwku8g03y1i68AARLJJ4/3O58=",
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
+      }
     },
     "compressible": {
-      "version": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
-      "integrity": "sha1-/tocf3YXkScyspv4zyYlKiC57s0="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
+      "integrity": "sha1-/tocf3YXkScyspv4zyYlKiC57s0=",
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "compression": {
-      "version": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
       "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
+      "requires": {
+        "accepts": "1.3.3",
+        "bytes": "2.3.0",
+        "compressible": "2.0.10",
+        "debug": "2.2.0",
+        "on-headers": "1.0.1",
+        "vary": "1.1.1"
+      },
       "dependencies": {
         "bytes": {
-          "version": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
           "integrity": "sha1-1baAoWW2IBc5rLYRVCqrwtjOsHA="
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }
     },
     "concat-map": {
-      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "connect-flash": {
-      "version": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
       "integrity": "sha1-2GMPJtlaf4UfmVax6MxnMvO2qjA="
     },
     "connect-mongo": {
-      "version": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-1.3.2.tgz",
-      "integrity": "sha1-fL9Y3/8mdg5eAOAX0KhbS8kLnTc="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-1.3.2.tgz",
+      "integrity": "sha1-fL9Y3/8mdg5eAOAX0KhbS8kLnTc=",
+      "requires": {
+        "bluebird": "3.5.0",
+        "mongodb": "2.2.29"
+      }
     },
     "content-disposition": {
-      "version": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
-      "version": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
     },
     "cookie": {
-      "version": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-parser": {
-      "version": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
-      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
     },
     "cookie-signature": {
-      "version": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookiejar": {
-      "version": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
       "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
       "dev": true
     },
     "core-util-is": {
-      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crc": {
-      "version": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
       "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms="
     },
     "crc32-stream": {
-      "version": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "requires": {
+        "crc": "3.4.4",
+        "readable-stream": "2.3.3"
+      }
     },
     "d": {
-      "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "requires": {
+        "es5-ext": "0.10.23"
+      }
     },
     "d3": {
-      "version": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
       "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
     },
     "debug": {
-      "version": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
-      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "optional": true
     },
     "deep-eql": {
-      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
       "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
       "dev": true,
+      "requires": {
+        "type-detect": "3.0.0"
+      },
       "dependencies": {
         "type-detect": {
-          "version": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
           "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
           "dev": true
         }
       }
     },
     "delayed-stream": {
-      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "depd": {
-      "version": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
       "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
     },
     "destroy": {
-      "version": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "dicer": {
-      "version": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.14",
+        "streamsearch": "0.1.2"
+      },
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "diff": {
-      "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
     "ee-first": {
-      "version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
-      "version": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "end-of-stream": {
-      "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "es5-ext": {
-      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg="
+      "version": "0.10.23",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
-      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-promise": {
-      "version": "git+https://github.com/stefanpenner/es6-promise.git#f046478d580c703edc9b319d34f6882ffc7bc73e"
+      "version": "git+https://github.com/stefanpenner/es6-promise.git#7f82a5649202af5e4757d969e54419d38ed57277"
     },
     "es6-symbol": {
-      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "es6-weak-map": {
-      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-html": {
-      "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
-      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "esprima": {
-      "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "esutils": {
-      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etag": {
-      "version": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
       "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
     },
     "event-emitter": {
-      "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "express": {
-      "version": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
-      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI="
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
+      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
+      "requires": {
+        "accepts": "1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "finalhandler": "1.0.3",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "1.1.4",
+        "qs": "6.4.0",
+        "range-parser": "1.2.0",
+        "send": "0.15.3",
+        "serve-static": "1.12.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "1.1.1"
+      }
     },
     "express-session": {
-      "version": "https://registry.npmjs.org/express-session/-/express-session-1.15.3.tgz",
-      "integrity": "sha1-21RfBDWnsbIorgLagZf2UUFzXGc="
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.3.tgz",
+      "integrity": "sha1-21RfBDWnsbIorgLagZf2UUFzXGc=",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "crc": "3.4.4",
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "on-headers": "1.0.1",
+        "parseurl": "1.3.1",
+        "uid-safe": "2.1.4",
+        "utils-merge": "1.0.0"
+      }
     },
     "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
+    "fast-deep-equal": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-0.1.0.tgz",
+      "integrity": "sha1-XG9FmaumszPuM0Li7ZeGcvEAH40="
+    },
     "finalhandler": {
-      "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
+      "requires": {
+        "debug": "2.6.7",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      }
     },
     "flat": {
-      "version": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
-      "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
+      "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8=",
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.2.0.tgz",
       "integrity": "sha1-ml47kpX5gLJiPPZPojixTOvKcHs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "formidable": {
-      "version": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
       "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
       "dev": true
     },
     "forwarded": {
-      "version": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
       "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
     },
     "fresh": {
-      "version": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
     },
     "fs.realpath": {
-      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "get-func-name": {
-      "version": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "git-rev-sync": {
-      "version": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.9.1.tgz",
-      "integrity": "sha1-oMLj3TkqvPa3aWLif8dfsyI0Sc4="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.9.1.tgz",
+      "integrity": "sha1-oMLj3TkqvPa3aWLif8dfsyI0Sc4=",
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "graceful-fs": "4.1.11",
+        "shelljs": "0.7.7"
+      }
     },
     "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU="
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "graceful-fs": {
-      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
-      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
     },
     "growl": {
-      "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "handlebars": {
-      "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
     },
     "has-ansi": {
-      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
-      "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "hooks-fixed": {
-      "version": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
       "integrity": "sha1-oB2JTVKsf2WZu7H2PfycQR33DLo="
     },
     "http-errors": {
-      "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
+      "requires": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      }
     },
     "iconv-lite": {
-      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
       "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
     },
     "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "interpret": {
-      "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
       "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
     },
     "ipaddr.js": {
-      "version": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
       "integrity": "sha1-HgOlL9rYOou7KyXL9JmLTP/NPew="
     },
     "is-buffer": {
-      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-promise": {
-      "version": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "isarray": {
-      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "js-tokens": {
-      "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY="
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "3.1.3"
+      }
     },
     "json-schema-ref-parser": {
-      "version": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-3.1.2.tgz",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-3.1.2.tgz",
       "integrity": "sha1-o47Ld3T4fzLn65cj1ZITkOdqmkI=",
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "debug": "2.6.7",
+        "es6-promise": "3.3.1",
+        "js-yaml": "3.8.4",
+        "ono": "2.2.5",
+        "z-schema": "3.18.2"
+      },
       "dependencies": {
         "es6-promise": {
-          "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
           "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
         }
       }
     },
     "json-schema-to-typescript": {
-      "version": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-4.4.0.tgz",
-      "integrity": "sha1-xe6uUFwYUgHt6SjpBttAwVWNPg4=",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-4.4.1.tgz",
+      "integrity": "sha1-FmGHYD4op/1mnDKN3AOrWPiHu5U=",
+      "requires": {
+        "cli-color": "1.2.0",
+        "json-schema-ref-parser": "3.1.2",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.4",
+        "minimist": "1.2.0",
+        "mz": "2.6.0",
+        "stdin": "0.0.1"
+      },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "json-schema-traverse": {
-      "version": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.0.tgz",
-      "integrity": "sha1-ABbAscoe/kbUTTdUG838Gdz64Ns="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
-      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json2csv": {
-      "version": "https://registry.npmjs.org/json2csv/-/json2csv-3.7.3.tgz",
-      "integrity": "sha1-2s/fp/sMGxsWOGjcdfOQLQIzVOw="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-3.8.0.tgz",
+      "integrity": "sha1-ra89/CD+duw6aucsrUTvLnKAZ40=",
+      "requires": {
+        "cli-table": "0.3.1",
+        "commander": "2.11.0",
+        "debug": "2.6.7",
+        "flat": "2.0.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.get": "4.4.2",
+        "lodash.set": "4.3.2",
+        "lodash.uniq": "4.5.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "json3": {
-      "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "kareem": {
-      "version": "https://registry.npmjs.org/kareem/-/kareem-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.4.1.tgz",
       "integrity": "sha1-7XYgAET6BB7zK02oJh4lU/EXNTE="
     },
     "kind-of": {
-      "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "lazy-cache": {
-      "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "optional": true
     },
     "lazystream": {
-      "version": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
     },
     "lodash": {
-      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
-      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
-      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
-      "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
-      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
-      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.clonedeep": {
-      "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.create": {
-      "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.flatten": {
-      "version": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.get": {
-      "version": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isarguments": {
-      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
-      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isequal": {
-      "version": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.keys": {
-      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.set": {
-      "version": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.uniq": {
-      "version": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "longest": {
-      "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "lru-queue": {
-      "version": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "0.10.23"
+      }
     },
     "marked": {
       "version": "0.3.6",
@@ -882,68 +1504,135 @@
       "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
     },
     "media-typer": {
-      "version": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memoizee": {
-      "version": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.5.tgz",
-      "integrity": "sha1-G8PqHkvgVt1HXVIZede+PV5bIcg="
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.5.tgz",
+      "integrity": "sha1-G8PqHkvgVt1HXVIZede+PV5bIcg=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-weak-map": "2.0.2",
+        "event-emitter": "0.3.5",
+        "is-promise": "2.1.0",
+        "lru-queue": "0.1.0",
+        "next-tick": "1.0.0",
+        "timers-ext": "0.1.2"
+      }
     },
     "merge-descriptors": {
-      "version": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "methods": {
-      "version": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
-      "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
       "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
     },
     "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
       "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
     },
     "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
-      "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
     "mocha": {
-      "version": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         }
@@ -955,333 +1644,593 @@
       "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
     "moment-timezone": {
-      "version": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
-      "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A="
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
+      "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
+      "requires": {
+        "moment": "2.18.1"
+      }
     },
     "mongodb": {
-      "version": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.28.tgz",
-      "integrity": "sha1-2P9FdUNm4Dlz+iWb9PEUR4WNplc=",
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.29.tgz",
+      "integrity": "sha512-MrQvIsN6zN80I4hdFo8w46w51cIqD2FJBGsUfApX9GmjXA1aCclEAJbOHaQWjCtabeWq57S3ECzqEKg/9bdBhA==",
+      "requires": {
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.13",
+        "readable-stream": "2.2.7"
+      },
       "dependencies": {
         "es6-promise": {
-          "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
           "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE="
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         }
       }
     },
     "mongodb-core": {
-      "version": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.12.tgz",
-      "integrity": "sha1-FTEZJRG8Fu8WCsauDMRndv/YRR0="
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.13.tgz",
+      "integrity": "sha512-mbcvqLLZwVcpTrsfBDY3hRNk2SDNJWOvKKxFJSc0pnUBhYojymBc/L0THfQsWwKJrkb2nIXSjfFll1mG/I5OqQ==",
+      "requires": {
+        "bson": "1.0.4",
+        "require_optional": "1.0.1"
+      }
     },
     "mongoose": {
-      "version": "https://registry.npmjs.org/mongoose/-/mongoose-4.10.6.tgz",
-      "integrity": "sha1-zFfa2Mi5FFy9LKVpalCBqVno/Ng=",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.11.1.tgz",
+      "integrity": "sha1-JWC22J50SwWFfQJMq4sxYGZxbj4=",
+      "requires": {
+        "async": "2.1.4",
+        "bson": "1.0.4",
+        "hooks-fixed": "2.0.0",
+        "kareem": "1.4.1",
+        "mongodb": "2.2.27",
+        "mpath": "0.3.0",
+        "mpromise": "0.5.5",
+        "mquery": "2.3.1",
+        "ms": "2.0.0",
+        "muri": "1.2.1",
+        "regexp-clone": "0.0.1",
+        "sliced": "1.0.1"
+      },
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-          "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ="
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+          "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+          "requires": {
+            "lodash": "4.17.4"
+          }
         },
         "es6-promise": {
-          "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
           "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
         },
         "mongodb": {
-          "version": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.27.tgz",
-          "integrity": "sha1-NBIgNNtm2YO89qta2yaiSnD+9uY="
+          "version": "2.2.27",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.27.tgz",
+          "integrity": "sha1-NBIgNNtm2YO89qta2yaiSnD+9uY=",
+          "requires": {
+            "es6-promise": "3.2.1",
+            "mongodb-core": "2.1.11",
+            "readable-stream": "2.2.7"
+          }
         },
         "mongodb-core": {
-          "version": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.11.tgz",
-          "integrity": "sha1-HDh3bOsXSZepnCiGDu2QKNqbPho="
+          "version": "2.1.11",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.11.tgz",
+          "integrity": "sha1-HDh3bOsXSZepnCiGDu2QKNqbPho=",
+          "requires": {
+            "bson": "1.0.4",
+            "require_optional": "1.0.1"
+          }
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE="
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         }
       }
     },
     "morgan": {
-      "version": "https://registry.npmjs.org/morgan/-/morgan-1.8.2.tgz",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.8.2.tgz",
       "integrity": "sha1-eErHc05KRTqcbm6GgKkyknXItoc=",
+      "requires": {
+        "basic-auth": "1.1.0",
+        "debug": "2.6.8",
+        "depd": "1.1.0",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      },
       "dependencies": {
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
     "mpath": {
-      "version": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
       "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q="
     },
     "mpromise": {
-      "version": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
       "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
     },
     "mquery": {
-      "version": "https://registry.npmjs.org/mquery/-/mquery-2.3.1.tgz",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.1.tgz",
       "integrity": "sha1-mrNnSXFIAP8LtTpoHOS8TV8HyHs=",
+      "requires": {
+        "bluebird": "2.10.2",
+        "debug": "2.6.8",
+        "regexp-clone": "0.0.1",
+        "sliced": "0.0.5"
+      },
       "dependencies": {
         "bluebird": {
-          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+          "version": "2.10.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
           "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "sliced": {
-          "version": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
           "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
         }
       }
     },
     "ms": {
-      "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multer": {
-      "version": "https://registry.npmjs.org/multer/-/multer-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.0.tgz",
       "integrity": "sha1-CSsmcPaEb6SRSWXvyM+Uwg/sbNI=",
+      "requires": {
+        "append-field": "0.1.0",
+        "busboy": "0.2.14",
+        "concat-stream": "1.6.0",
+        "mkdirp": "0.5.1",
+        "object-assign": "3.0.0",
+        "on-finished": "2.3.0",
+        "type-is": "1.6.15",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
-        },
         "object-assign": {
-          "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         }
       }
     },
     "muri": {
-      "version": "https://registry.npmjs.org/muri/-/muri-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.1.tgz",
       "integrity": "sha1-7H6lzmympSPrGrNbrNpfqBbJqjw="
     },
     "mz": {
-      "version": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
-      "integrity": "sha1-yLhSHZWN8KTydoAl22nHGe5O8c4="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
+      "integrity": "sha1-yLhSHZWN8KTydoAl22nHGe5O8c4=",
+      "requires": {
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
+      }
     },
     "negotiator": {
-      "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "next-tick": {
-      "version": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nodemailer": {
-      "version": "https://registry.npmjs.org/nodemailer/-/nodemailer-3.1.8.tgz",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-3.1.8.tgz",
       "integrity": "sha1-/r+sy0vSc2eEc6MJxstLSi88SOM="
     },
     "normalize-path": {
-      "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "1.0.2"
+      }
     },
     "oauth": {
-      "version": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
     },
     "object-assign": {
-      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "on-finished": {
-      "version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "on-headers": {
-      "version": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
       "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "ono": {
-      "version": "https://registry.npmjs.org/ono/-/ono-2.2.5.tgz",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-2.2.5.tgz",
       "integrity": "sha1-2vCUiLURdNp6fkJ136sxtDj/oOM="
     },
     "optimist": {
-      "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      }
     },
     "parseurl": {
-      "version": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
     },
     "passport": {
-      "version": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
-      "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
+      "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
+      "requires": {
+        "passport-strategy": "1.0.0",
+        "pause": "0.0.1"
+      }
     },
     "passport-facebook": {
-      "version": "https://registry.npmjs.org/passport-facebook/-/passport-facebook-2.1.1.tgz",
-      "integrity": "sha1-w50LUq5NWRYyRaTiGnubYyEwMxE="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/passport-facebook/-/passport-facebook-2.1.1.tgz",
+      "integrity": "sha1-w50LUq5NWRYyRaTiGnubYyEwMxE=",
+      "requires": {
+        "passport-oauth2": "1.4.0"
+      }
     },
     "passport-github2": {
-      "version": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.10.tgz",
-      "integrity": "sha1-UKIcHpW4MRPk2jLIHCwaZEKbtb0="
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.10.tgz",
+      "integrity": "sha1-UKIcHpW4MRPk2jLIHCwaZEKbtb0=",
+      "requires": {
+        "passport-oauth2": "1.4.0"
+      }
     },
     "passport-google-oauth20": {
-      "version": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-1.0.0.tgz",
-      "integrity": "sha1-O5YOih1w0dvnlGFcgnxoxAOSpdA="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-1.0.0.tgz",
+      "integrity": "sha1-O5YOih1w0dvnlGFcgnxoxAOSpdA=",
+      "requires": {
+        "passport-oauth2": "1.4.0"
+      }
     },
     "passport-local": {
-      "version": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
-      "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
+      "requires": {
+        "passport-strategy": "1.0.0"
+      }
     },
     "passport-oauth2": {
-      "version": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
-      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
+      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0=",
+      "requires": {
+        "oauth": "0.9.15",
+        "passport-strategy": "1.0.0",
+        "uid2": "0.0.3",
+        "utils-merge": "1.0.0"
+      }
     },
     "passport-strategy": {
-      "version": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
       "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
     },
     "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
-      "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-to-regexp": {
-      "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pathval": {
-      "version": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
     "pause": {
-      "version": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "process-nextick-args": {
-      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "proxy-addr": {
-      "version": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
-      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
+      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
+      "requires": {
+        "forwarded": "0.1.0",
+        "ipaddr.js": "1.3.0"
+      }
     },
     "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
       "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
     },
     "random-bytes": {
-      "version": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "range-parser": {
-      "version": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
-      "version": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
-      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
+      "requires": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
+        "unpipe": "1.0.0"
+      }
     },
     "readable-stream": {
-      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-      "integrity": "sha1-B5azH412iAB/8Lk6gIjTSqF8D3I="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "rechoir": {
-      "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "1.3.3"
+      }
     },
     "regexp-clone": {
-      "version": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
     },
     "remove-trailing-separator": {
-      "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
       "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
     },
     "repeat-string": {
-      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "require_optional": {
-      "version": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "5.3.0"
+      }
     },
     "resolve": {
-      "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
-      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "right-align": {
-      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "safe-buffer": {
-      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
-      "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "send": {
-      "version": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
-      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk="
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
+      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
+      "requires": {
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "1.6.1",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      }
     },
     "serve-static": {
-      "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
-      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI="
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
+      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.1",
+        "send": "0.15.3"
+      }
     },
     "setprototypeof": {
-      "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "shelljs": {
-      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E="
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      }
     },
     "sliced": {
-      "version": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "source-map": {
-      "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "requires": {
+        "amdefine": "1.0.1"
+      }
     },
     "sprintf-js": {
-      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "statuses": {
-      "version": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
     "stdin": {
-      "version": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
       "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4="
     },
     "streamsearch": {
-      "version": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "strip-ansi": {
-      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "striptags": {
       "version": "3.0.1",
@@ -1289,167 +2238,283 @@
       "integrity": "sha1-SPDWkyVJxHuzWCkgyHUnz0mhYME="
     },
     "superagent": {
-      "version": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
       "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "2.6.7",
+        "extend": "3.0.1",
+        "form-data": "2.2.0",
+        "formidable": "1.1.1",
+        "methods": "1.1.2",
+        "mime": "1.3.4",
+        "qs": "6.4.0",
+        "readable-stream": "2.3.3"
+      }
     },
     "supertest": {
-      "version": "https://registry.npmjs.org/supertest/-/supertest-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.0.0.tgz",
       "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "methods": "1.1.2",
+        "superagent": "3.5.2"
+      }
     },
     "supports-color": {
-      "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
     },
     "sweetalert2": {
-      "version": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-6.6.5.tgz",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-6.6.5.tgz",
       "integrity": "sha1-///BBkcR/3hwvIrv4WePlezCkNs="
     },
     "tar-stream": {
-      "version": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY="
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+      "requires": {
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.0",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
     },
     "thenify": {
-      "version": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "1.3.0"
+      }
     },
     "thenify-all": {
-      "version": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": "3.3.0"
+      }
     },
     "timers-ext": {
-      "version": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
-      "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
+      "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
+      "requires": {
+        "es5-ext": "0.10.23",
+        "next-tick": "1.0.0"
+      }
     },
     "tslib": {
-      "version": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
       "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw=",
       "dev": true
     },
     "tslint": {
-      "version": "https://registry.npmjs.org/tslint/-/tslint-5.4.3.tgz",
-      "integrity": "sha1-dhyEArgONHt3M6BDkKdXslNYBGc=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.5.0.tgz",
+      "integrity": "sha1-EOjas+MGH6YelELozuOYKs8gpqo=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "colors": "1.1.2",
+        "commander": "2.11.0",
+        "diff": "3.2.0",
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "resolve": "1.3.3",
+        "semver": "5.3.0",
+        "tslib": "1.7.1",
+        "tsutils": "2.5.1"
+      },
       "dependencies": {
         "colors": {
-          "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true
         }
       }
     },
     "tslint-language-service": {
-      "version": "https://registry.npmjs.org/tslint-language-service/-/tslint-language-service-0.9.6.tgz",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/tslint-language-service/-/tslint-language-service-0.9.6.tgz",
       "integrity": "sha1-iCuwcEz4OXszLdwK9xaMfyLyeeo=",
       "dev": true
     },
     "tsutils": {
-      "version": "https://registry.npmjs.org/tsutils/-/tsutils-2.4.0.tgz",
-      "integrity": "sha1-rUzm26Dlo+2934Ymt8oEB4IYn+o=",
-      "dev": true
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.5.1.tgz",
+      "integrity": "sha1-wgATkMee7Bpcz6esEtWZY5aD4M8=",
+      "dev": true,
+      "requires": {
+        "tslib": "1.7.1"
+      }
     },
     "type-detect": {
-      "version": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
       "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
     },
     "type-is": {
-      "version": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA="
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.15"
+      }
     },
     "typedarray": {
-      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
+      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
       "dev": true
     },
     "uglify-js": {
-      "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "optional": true
         }
       }
     },
     "uglify-to-browserify": {
-      "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
     "uid-safe": {
-      "version": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-      "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
+      "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
+      "requires": {
+        "random-bytes": "1.0.0"
+      }
     },
     "uid2": {
-      "version": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "unpipe": {
-      "version": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "util-deprecate": {
-      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
-      "version": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
     },
     "validator": {
-      "version": "https://registry.npmjs.org/validator/-/validator-6.3.0.tgz",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-6.3.0.tgz",
       "integrity": "sha1-R84j7Y1Ord+p1LjvAHG2zxB418g="
     },
     "vary": {
-      "version": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
       "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
     },
     "walkdir": {
-      "version": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
     },
     "whatwg-fetch": {
-      "version": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "window-size": {
-      "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "optional": true
     },
     "wordwrap": {
-      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xtend": {
-      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yargs": {
-      "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
     },
     "z-schema": {
-      "version": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.2.tgz",
-      "integrity": "sha1-5CIZa17+YLRq3vPD8q7y3qqREWE="
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.2.tgz",
+      "integrity": "sha1-5CIZa17+YLRq3vPD8q7y3qqREWE=",
+      "requires": {
+        "commander": "2.11.0",
+        "lodash.get": "4.4.2",
+        "lodash.isequal": "4.5.0",
+        "validator": "6.3.0"
+      }
     },
     "zip-stream": {
-      "version": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.1.tgz",
-      "integrity": "sha1-Uha0i7tNJlH2TVxubwnrSnOZ1Vc="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.0",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.3"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "supertest": "^3.0.0",
     "tslint": "^5.4.3",
     "tslint-language-service": "^0.9.6",
-    "typescript": "^2.3.4"
+    "typescript": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@types/mongoose": "^4.7.8",
     "@types/morgan": "^1.7.32",
     "@types/multer": "0.0.33",
-    "@types/node": "^7.0.28",
+    "@types/node": "^8.0.8",
     "@types/nodemailer": "^1.3.32",
     "@types/passport": "^0.3.3",
     "@types/passport-facebook": "^2.1.3",

--- a/server/common.ts
+++ b/server/common.ts
@@ -474,7 +474,7 @@ export async function sendMailAsync(mail: nodemailer.SendMailOptions): Promise<n
 		});
 	});
 }
-function sanitize(input: string): string {
+export function sanitize(input: string): string {
 	if (typeof input !== "string") {
 		return "";
 	}

--- a/server/common.ts
+++ b/server/common.ts
@@ -223,26 +223,21 @@ export async function setDefaultSettings() {
 		return await Setting.find({ "name": key }).count() === 0;
 	}
 
-	if (await doesNotExist("applicationOpen")) {
-		await updateSetting("applicationOpen", new Date());
-	}
-	if (await doesNotExist("applicationClose")) {
-		await updateSetting("applicationClose", new Date());
-	}
-	if (await doesNotExist("confirmationOpen")) {
-		await updateSetting("confirmationOpen", new Date());
-	}
-	if (await doesNotExist("confirmationClose")) {
-		await updateSetting("confirmationClose", new Date());
-	}
-	if (await doesNotExist("teamsEnabled")) {
-		await updateSetting("teamsEnabled", true);
-	}
-	if (await doesNotExist("applicationBranches")) {
-		await updateSetting("applicationBranches", []);
-	}
-	if (await doesNotExist("confirmationBranches")) {
-		await updateSetting("confirmationBranches", []);
+	const DEFAULTS: any = {
+		"applicationOpen": new Date(),
+		"applicationClose": new Date(),
+		"confirmationOpen": new Date(),
+		"confirmationClose": new Date(),
+		"teamsEnabled": true,
+		"applicationBranches": [],
+		"confirmationBranches": []
+	};
+
+	for (let setting in DEFAULTS) {
+		if (await doesNotExist(setting)) {
+			await updateSetting(setting, DEFAULTS[setting]);
+			console.log(`Updated previously unset setting ${setting} to ${JSON.stringify(DEFAULTS[setting])}`);
+		}
 	}
 }
 export async function getSetting<T>(name: string, createMissing: boolean = true): Promise<T> {

--- a/server/common.ts
+++ b/server/common.ts
@@ -55,6 +55,7 @@ class Config implements IConfig.Main {
 		this.loadFromEnv();
 	}
 	protected loadFromJSON(fileName: string): void {
+		// tslint:disable-next-line:no-shadowed-variable
 		let config: IConfig.Main | null = null;
 		try {
 			config = JSON.parse(fs.readFileSync(path.resolve(__dirname, "./config", fileName), "utf8"));
@@ -99,94 +100,94 @@ class Config implements IConfig.Main {
 	protected loadFromEnv(): void {
 		// Secrets
 		if (process.env.SESSION_SECRET) {
-			this.secrets.session = process.env.SESSION_SECRET;
+			this.secrets.session = process.env.SESSION_SECRET!;
 			this.sessionSecretSet = true;
 		}
 		if (process.env.GITHUB_CLIENT_ID) {
-			this.secrets.github.id = process.env.GITHUB_CLIENT_ID;
+			this.secrets.github.id = process.env.GITHUB_CLIENT_ID!;
 		}
 		if (process.env.GITHUB_CLIENT_SECRET) {
-			this.secrets.github.secret = process.env.GITHUB_CLIENT_SECRET;
+			this.secrets.github.secret = process.env.GITHUB_CLIENT_SECRET!;
 		}
 		if (process.env.GOOGLE_CLIENT_ID) {
-			this.secrets.google.id = process.env.GOOGLE_CLIENT_ID;
+			this.secrets.google.id = process.env.GOOGLE_CLIENT_ID!;
 		}
 		if (process.env.GOOGLE_CLIENT_SECRET) {
-			this.secrets.google.secret = process.env.GOOGLE_CLIENT_SECRET;
+			this.secrets.google.secret = process.env.GOOGLE_CLIENT_SECRET!;
 		}
 		if (process.env.FACEBOOK_CLIENT_ID) {
-			this.secrets.facebook.id = process.env.FACEBOOK_CLIENT_ID;
+			this.secrets.facebook.id = process.env.FACEBOOK_CLIENT_ID!;
 		}
 		if (process.env.FACEBOOK_CLIENT_SECRET) {
-			this.secrets.facebook.secret = process.env.FACEBOOK_CLIENT_SECRET;
+			this.secrets.facebook.secret = process.env.FACEBOOK_CLIENT_SECRET!;
 		}
 		// Email
 		if (process.env.EMAIL_FROM) {
-			this.email.from = process.env.EMAIL_FROM;
+			this.email.from = process.env.EMAIL_FROM!;
 		}
 		if (process.env.EMAIL_HOST) {
-			this.email.host = process.env.EMAIL_HOST;
+			this.email.host = process.env.EMAIL_HOST!;
 		}
 		if (process.env.EMAIL_USERNAME) {
-			this.email.username = process.env.EMAIL_USERNAME;
+			this.email.username = process.env.EMAIL_USERNAME!;
 		}
 		if (process.env.EMAIL_PASSWORD) {
-			this.email.password = process.env.EMAIL_PASSWORD;
+			this.email.password = process.env.EMAIL_PASSWORD!;
 		}
 		if (process.env.EMAIL_PORT) {
-			let port = parseInt(process.env.EMAIL_PORT, 10);
+			let port = parseInt(process.env.EMAIL_PORT!, 10);
 			if (!isNaN(port) && port > 0) {
 				this.email.port = port;
 			}
 		}
 		// Server
-		if (process.env.PRODUCTION && process.env.PRODUCTION.toLowerCase() === "true") {
+		if (process.env.PRODUCTION && process.env.PRODUCTION!.toLowerCase() === "true") {
 			this.server.isProduction = true;
 		}
 		if (process.env.PORT) {
-			let port = parseInt(process.env.PORT, 10);
+			let port = parseInt(process.env.PORT!, 10);
 			if (!isNaN(port) && port > 0) {
 				this.server.port = port;
 			}
 		}
 		if (process.env.VERSION_HASH) {
-			this.server.versionHash = process.env.VERSION_HASH;
+			this.server.versionHash = process.env.VERSION_HASH!;
 		}
 		if (process.env.SOURCE_VERSION) {
-			this.server.versionHash = process.env.SOURCE_VERSION;
+			this.server.versionHash = process.env.SOURCE_VERSION!;
 		}
 		if (process.env.WORKFLOW_RELEASE_CREATED_AT) {
-			this.server.workflowReleaseCreatedAt = process.env.WORKFLOW_RELEASE_CREATED_AT;
+			this.server.workflowReleaseCreatedAt = process.env.WORKFLOW_RELEASE_CREATED_AT!;
 		}
 		if (process.env.WORKFLOW_RELEASE_SUMMARY) {
-			this.server.workflowReleaseSummary = process.env.WORKFLOW_RELEASE_SUMMARY;
+			this.server.workflowReleaseSummary = process.env.WORKFLOW_RELEASE_SUMMARY!;
 		}
 		if (process.env.COOKIE_MAX_AGE) {
-			let maxAge = parseInt(process.env.COOKIE_MAX_AGE, 10);
+			let maxAge = parseInt(process.env.COOKIE_MAX_AGE!, 10);
 			if (!isNaN(maxAge) && maxAge > 0) {
 				this.server.cookieMaxAge = maxAge;
 			}
 		}
-		if (process.env.COOKIE_SECURE_ONLY && process.env.COOKIE_SECURE_ONLY.toLowerCase() === "true") {
+		if (process.env.COOKIE_SECURE_ONLY && process.env.COOKIE_SECURE_ONLY!.toLowerCase() === "true") {
 			this.server.cookieSecureOnly = true;
 		}
 		if (process.env.MONGO_URL) {
-			this.server.mongoURL = process.env.MONGO_URL;
+			this.server.mongoURL = process.env.MONGO_URL!;
 		}
 		if (process.env.UNIQUE_APP_ID) {
-			this.server.uniqueAppID = process.env.UNIQUE_APP_ID;
+			this.server.uniqueAppID = process.env.UNIQUE_APP_ID!;
 		}
 		// Admins
 		if (process.env.ADMIN_EMAILS) {
-			this.admins = process.env.ADMIN_EMAILS.split(",");
+			this.admins = process.env.ADMIN_EMAILS!.split(",");
 		}
 		// Event name
 		if (process.env.EVENT_NAME) {
-			this.eventName = process.env.EVENT_NAME;
+			this.eventName = process.env.EVENT_NAME!;
 		}
 
 		if (process.env.MAX_TEAM_SIZE) {
-			this.maxTeamSize = process.env.MAX_TEAM_SIZE;
+			this.maxTeamSize = parseInt(process.env.MAX_TEAM_SIZE!, 10);
 		}
 	}
 }
@@ -215,9 +216,7 @@ import * as mongoose from "mongoose";
 mongoose.connect(url.resolve(config.server.mongoURL, config.server.uniqueAppID));
 export {mongoose};
 
-import {
-	ISettingMongoose, Setting
-} from "./schema";
+import { Setting } from "./schema";
 
 export async function setDefaultSettings() {
 	async function doesNotExist(key: string): Promise<boolean> {
@@ -330,21 +329,16 @@ export enum ApplicationType {
 export async function timeLimited(request: express.Request, response: express.Response, next: express.NextFunction) {
 	let requestType: ApplicationType = request.url.match(/^\/apply/) ? ApplicationType.Application : ApplicationType.Confirmation;
 
-	let openKey: string;
-	let closeKey: string;
+	let openDate: moment.Moment;
+	let closeDate: moment.Moment;
 	if (requestType === ApplicationType.Application) {
-		openKey = "applicationOpen";
-		closeKey = "applicationClose";
+		openDate = moment(await getSetting<Date>("applicationOpen"));
+		closeDate = moment(await getSetting<Date>("applicationClose"));
 	}
 	else {
-		openKey = "confirmationOpen";
-		closeKey = "confirmationClose";
+		openDate = moment(await getSetting<Date>("confirmationOpen"));
+		closeDate = moment(await getSetting<Date>("confirmationClose"));
 	}
-
-	let [openDate, closeDate] = (await Promise.all<ISettingMongoose>([
-		Setting.findOne({ "name": openKey }),
-		Setting.findOne({ "name": closeKey })
-	])).map(setting => moment(setting.value as Date));
 
 	if (moment().isBetween(openDate, closeDate)) {
 		next();

--- a/server/common.ts
+++ b/server/common.ts
@@ -220,47 +220,30 @@ import {
 } from "./schema";
 
 export async function setDefaultSettings() {
-	if (await Setting.find({ "name": "applicationOpen" }).count() === 0) {
-		await new Setting({
-			"name": "applicationOpen",
-			"value": new Date()
-		}).save();
+	async function doesNotExist(key: string): Promise<boolean> {
+		return await Setting.find({ "name": key }).count() === 0;
 	}
-	if (await Setting.find({ "name": "applicationClose" }).count() === 0) {
-		await new Setting({
-			"name": "applicationClose",
-			"value": new Date()
-		}).save();
+
+	if (await doesNotExist("applicationOpen")) {
+		await updateSetting("applicationOpen", new Date());
 	}
-	if (await Setting.find({ "name": "confirmationOpen" }).count() === 0) {
-		await new Setting({
-			"name": "confirmationOpen",
-			"value": new Date()
-		}).save();
+	if (await doesNotExist("applicationClose")) {
+		await updateSetting("applicationClose", new Date());
 	}
-	if (await Setting.find({ "name": "confirmationClose" }).count() === 0) {
-		await new Setting({
-			"name": "confirmationClose",
-			"value": new Date()
-		}).save();
+	if (await doesNotExist("confirmationOpen")) {
+		await updateSetting("confirmationOpen", new Date());
 	}
-	if (await Setting.find({ "name": "teamsEnabled" }).count() === 0) {
-		await new Setting({
-			"name": "teamsEnabled",
-			"value": true
-		}).save();
+	if (await doesNotExist("confirmationClose")) {
+		await updateSetting("confirmationClose", new Date());
 	}
-	if (await Setting.find({ "name": "applicationBranches" }).count() === 0) {
-		await new Setting({
-			"name": "applicationBranches",
-			"value": []
-		}).save();
+	if (await doesNotExist("teamsEnabled")) {
+		await updateSetting("teamsEnabled", true);
 	}
-	if (await Setting.find({ "name": "confirmationBranches" }).count() === 0) {
-		await new Setting({
-			"name": "confirmationBranches",
-			"value": []
-		}).save();
+	if (await doesNotExist("applicationBranches")) {
+		await updateSetting("applicationBranches", []);
+	}
+	if (await doesNotExist("confirmationBranches")) {
+		await updateSetting("confirmationBranches", []);
 	}
 }
 export async function getSetting<T>(name: string, createMissing: boolean = true): Promise<T> {
@@ -282,6 +265,9 @@ export async function getSetting<T>(name: string, createMissing: boolean = true)
 export async function updateSetting<T>(name: string, value: T, createMissing: boolean = true): Promise<void> {
 	let setting = await Setting.findOne({ name });
 	if (!setting) {
+		if (!createMissing) {
+			throw new Error("Setting not found to update");
+		}
 		await new Setting({ name, value }).save();
 	}
 	else {

--- a/server/config/questions.json
+++ b/server/config/questions.json
@@ -1,6 +1,33 @@
 [
     {
         "name": "Participant",
+        "text": [
+            {
+                "for": "name",
+                "type": "h3",
+                "content": "Some <h3> content"
+            },
+            {
+                "for": "phone",
+                "type": "h6",
+                "content": "Text blocks are stackable"
+            },
+            {
+                "for": "phone",
+                "type": "p",
+                "content": "Some extra information about why we need this"
+            },
+            {
+                "for": "phone",
+                "type": "p",
+                "content": "Another paragraph describing why we need this"
+            },
+            {
+                "for": "tshirt-size",
+                "type": "h3",
+                "content": "Some <h3> content near the end"
+            }
+        ],
         "questions": [
             {
                 "name": "name",

--- a/server/config/questions.json
+++ b/server/config/questions.json
@@ -26,6 +26,11 @@
                 "for": "tshirt-size",
                 "type": "h3",
                 "content": "Some <h3> content near the end"
+            },
+            {
+                "for": "end",
+                "type": "p",
+                "content": "Example footer text that appears right above the submit button"
             }
         ],
         "questions": [

--- a/server/config/questions.json
+++ b/server/config/questions.json
@@ -23,6 +23,11 @@
                 "content": "Another paragraph describing why we need this"
             },
             {
+                "for": "phone",
+                "type": "p",
+                "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas egestas ipsum ut pharetra egestas. Quisque cursus ex quis condimentum ultricies. Vestibulum quis diam eu tortor tincidunt molestie. Vivamus commodo tristique eros vel scelerisque. Vivamus sed velit id lectus laoreet facilisis. Quisque lacinia pellentesque dui, eu venenatis libero porta ut. Etiam id aliquet nibh. Donec eu turpis arcu. Duis pretium tincidunt turpis, id viverra tortor auctor in. Proin eget gravida purus. Nam sed lorem at enim dapibus tempus id non justo. Nullam id est erat."
+            },
+            {
                 "for": "tshirt-size",
                 "type": "h3",
                 "content": "Some <h3> content near the end"

--- a/server/config/questions.schema.json
+++ b/server/config/questions.schema.json
@@ -13,6 +13,40 @@
             "name": {
                 "type": "string"
             },
+            "text": {
+                "title": "Text blocks",
+                "type": "array",
+                "items": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "h1",
+                                    "h2",
+                                    "h3",
+                                    "h4",
+                                    "h5",
+                                    "h6",
+                                    "p"
+                                ]
+                            },
+                            "content": {
+                                "type": "string"
+                            },
+                            "for": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "content",
+                            "for"
+                        ]
+                    }
+                ]
+            },
             "questions": {
                 "title": "Questions",
                 "type": "array",

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -279,7 +279,7 @@ app.use(passport.session());
 export let authRoutes = express.Router();
 
 function getExternalPort(request: express.Request): number {
-	let host = request.headers.host!;
+	let host = request.headers.host as string;
 	// IPv6 literal support
 	let offset = host[0] === "[" ? host.indexOf("]") + 1 : 0;
 	let index = host.indexOf(":", offset);

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -279,7 +279,16 @@ app.use(passport.session());
 export let authRoutes = express.Router();
 
 function getExternalPort(request: express.Request): number {
-	let host = request.headers.host as string;
+	function defaultPort(): number {
+		// Default ports for HTTP and HTTPS
+		return request.protocol === "http" ? 80 : 443;
+	}
+
+	let host = request.headers.host;
+	if (!host || Array.isArray(host)) {
+		return defaultPort();
+	}
+
 	// IPv6 literal support
 	let offset = host[0] === "[" ? host.indexOf("]") + 1 : 0;
 	let index = host.indexOf(":", offset);
@@ -287,8 +296,7 @@ function getExternalPort(request: express.Request): number {
 		return parseInt(host.substring(index + 1), 10);
 	}
 	else {
-		// Default ports for HTTP and HTTPS
-		return request.protocol === "http" ? 80 : 443;
+		return defaultPort();
 	}
 }
 let validatedHostNames: string[] = [];

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -55,7 +55,7 @@ templateRoutes.use(async (request, response, next) => {
 		return;
 	}
 
-	let userAgent = request.headers["user-agent"];
+	let userAgent = request.headers["user-agent"] as string | undefined;
 	const minBrowser = {
 		msie: "12", // Microsoft Edge+ (no support for IE)
 		safari: "7.1" // Safari v7 was released in 2013

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -338,6 +338,13 @@ async function applicationBranchHandler(request: express.Request, response: expr
 	});
 	// tslint:enable:no-string-literal
 
+	let endText: string = "";
+	if (questionBranch.text) {
+		endText = questionBranch.text.filter(text => text.for === "end").map(text => {
+			return `<${text.type} style="font-size: 90%; text-align: center;">${sanitize(text.content)}</${text.type}>`;
+		}).join("\n");
+	}
+
 	let thisUser = await User.findById(user._id) as IUserMongoose;
 	if (requestType === ApplicationType.Application) {
 		thisUser.applicationStartTime = new Date();
@@ -354,7 +361,8 @@ async function applicationBranchHandler(request: express.Request, response: expr
 			teamsEnabled: await getSetting<boolean>("teamsEnabled")
 		},
 		branch: questionBranch.name,
-		questionData
+		questionData,
+		endText
 	};
 
 	response.send(requestType === ApplicationType.Application ? registerTemplate(templateData) : confirmTemplate(templateData));

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -329,7 +329,7 @@ async function applicationBranchHandler(request: express.Request, response: expr
 
 		if (questionBranch.text) {
 			let textContent: string = questionBranch.text.filter(text => text.for === question.name).map(text => {
-				return `<${text.type} style="text-align: center;">${sanitize(text.content)}</${text.type}>`;
+				return `<${text.type}>${sanitize(text.content)}</${text.type}>`;
 			}).join("\n");
 			question["textContent"] = textContent;
 		}

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -226,6 +226,7 @@ export interface IRegisterBranchChoiceTemplate extends ICommonTemplate {
 export interface IRegisterTemplate extends ICommonTemplate {
 	branch: string;
 	questionData: Questions;
+	endText: string;
 }
 export interface ResponseCount {
 	"response": string;


### PR DESCRIPTION
This PR adds the `text` property to branches defined in `questions.json` which is an array of objects of the form:
```
{
    "for": "question-name",
    "type": "h3",
    "content": "Some <h3> content"
}
```

The `type` defines which HTML element will represent this text content. Currently, it is restricted to the six header elements and the paragraph element. Header elements will be center-aligned while paragraph elements will be left-aligned.

The `for` property is the `name` of the question to which this text block will be attached. Text blocks appear before the question's label and options. The exception to this is when `"for": "end"` is specified. In this case, the text block will be attached right above the submit button at the bottom of the page. Additionally, the text size will be reduced to 90% and all content (including paragraph elements) will be center-aligned.

Texts blocks defined as being `for` the same question will "stack" and appear in the same order that they are defined in `questions.json`.

Additionally, this PR fixes a bug where settings could not be saved when all available branches were configured as no-ops (which would happen when starting from an empty database).