### PR TITLE
Add ability to interpolate form data in email templates

### DIFF
--- a/client/admin.html
+++ b/client/admin.html
@@ -266,6 +266,8 @@
 								<li><strong>\{{teamName}}</strong>: The user's team name if teams are enabled and the user has joined a team. Otherwise, will output <code>Teams not enabled</code> or <code>No team created or joined</code> respectively.</li>
 								<li><strong>\{{applicationBranch}}</strong>: The question branch name that the user applied / was accepted to.</li>
 								<li><strong>\{{confirmationBranch}}</strong>: The question branch name that the user RSVPed to.</li>
+								<li><strong>\{{application.<code>question-name</code>}}</strong>: Prints the user's response to the application question with the specified name from <code>questions.json</code>. Note that the question name is different from the question label. <a href="https://github.com/HackGT/registration/blob/master/server/config/questions.json" target="_blank">See the GitHub project</a> for details. Will print <code>N/A</code> if not yet answered.</li>
+								<li><strong>\{{confirmation.<code>question-name</code>}}</strong>: Prints the user's response to the confirmation question with the specified name from <code>questions.json</code>.</li>
 							</ul>
 						</div>
 					</div>

--- a/client/css/admin.css
+++ b/client/css/admin.css
@@ -112,6 +112,12 @@ canvas {
 .branch-role:nth-of-type(3n + 1) {
     margin-left: 0;
 }
+.branch-role > h4 {
+    height: 40px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 pre {
     overflow: auto;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/server/common.ts
+++ b/server/common.ts
@@ -577,7 +577,7 @@ import * as nodemailer from "nodemailer";
 import * as marked from "marked";
 // tslint:disable-next-line:no-var-requires
 const striptags = require("striptags");
-import { IUser, Team } from "./schema";
+import { IUser, Team, IFormItem } from "./schema";
 
 export let emailTransporter = nodemailer.createTransport({
 	host: config.email.host,
@@ -637,6 +637,25 @@ export async function renderEmailHTML(markdown: string, user: IUser): Promise<st
 		teamName = "Teams not enabled";
 	}
 
+	function formatFormItem(formItem: IFormItem | undefined): string {
+		if (formItem === undefined || formItem.value === null) {
+			return "N/A";
+		}
+		else if (typeof formItem.value === "string") {
+			return formItem.value;
+		}
+		else if (Array.isArray(formItem.value)) {
+			return formItem.value.join(", ");
+		}
+		else {
+			// Multer file
+			let file = formItem.value;
+			let formattedSize = formatSize(file.size);
+
+			return `\`${file.originalname}\` / ${formattedSize}`;
+		}
+	}
+
 	// Interpolate and sanitize variables
 	markdown = markdown.replace(/{{eventName}}/g, sanitize(config.eventName));
 	markdown = markdown.replace(/{{email}}/g, sanitize(user.email));
@@ -644,6 +663,14 @@ export async function renderEmailHTML(markdown: string, user: IUser): Promise<st
 	markdown = markdown.replace(/{{teamName}}/g, sanitize(teamName));
 	markdown = markdown.replace(/{{applicationBranch}}/g, sanitize(user.applicationBranch));
 	markdown = markdown.replace(/{{confirmationBranch}}/g, sanitize(user.confirmationBranch));
+	markdown = markdown.replace(/{{application\.([a-zA-Z0-9\- ]+)}}/g, (match, name: string) => {
+		let question = user.applicationData.find(data => data.name === name);
+		return formatFormItem(question);
+	});
+	markdown = markdown.replace(/{{confirmation\.([a-zA-Z0-9\- ]+)}}/g, (match, name: string) => {
+		let question = user.confirmationData.find(data => data.name === name);
+		return formatFormItem(question);
+	});
 
 	return await renderMarkdown(markdown);
 }

--- a/server/common.ts
+++ b/server/common.ts
@@ -566,6 +566,19 @@ export async function validateSchema(questionsFile: string, schemaFile: string =
 		return Promise.reject(new Error("Application branch names are not unique"));
 	}
 	else {
+		for (let i = 0; i < questionBranches.length; i++) {
+			for (let j = 0; j < questionBranches[i].questions.length; j++) {
+				// Render labels
+				questionBranches[i].questions[j].label = await renderMarkdown(questionBranches[i].questions[j].label, undefined, true);
+				// Render options (if they exist)
+				let type = questionBranches[i].questions[j].type;
+				if (type === "checkbox" || type === "radio" || type === "select") {
+					for (let k = 0; k < questionBranches[i].questions[j].options.length; k++) {
+						questionBranches[i].questions[j].options[k] = await renderMarkdown(questionBranches[i].questions[j].options[k], undefined, true);
+					}
+				}
+			}
+		}
 		return questionBranches;
 	}
 }

--- a/server/common.ts
+++ b/server/common.ts
@@ -655,7 +655,7 @@ export async function renderEmailHTML(markdown: string, user: IUser): Promise<st
 			return "N/A";
 		}
 		else if (typeof formItem.value === "string") {
-			return formItem.value;
+			return formItem.value.replace(/\n/g, "\n<br />");
 		}
 		else if (Array.isArray(formItem.value)) {
 			return formItem.value.join(", ");

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -358,9 +358,6 @@ async function applicationBranchHandler(request: express.Request, response: expr
 					}
 				}
 			}
-			question.options = await Promise.all(question.options.map(async (option) => {
-				return await renderMarkdown(option, undefined, true);
-			}));
 		}
 		else {
 			question["multi"] = false;
@@ -379,7 +376,6 @@ async function applicationBranchHandler(request: express.Request, response: expr
 			}))).join("\n");
 			question["textContent"] = textContent;
 		}
-		question.label = await renderMarkdown(question.label, undefined, true);
 
 		return question;
 	}));


### PR DESCRIPTION
* Can now interpolate submitted form data with `{{application.question-name}}` or `{{confirmation.question-name}}`. See [`questions.json`](https://github.com/HackGT/registration/blob/master/server/config/questions.json) for all questions with associated internal names.
* Fixes a bug where questions whose Markdown-rendered options were different from plain text would not be loaded correctly when the application was edited
* Fixes a minor visual bug with question branches with long names