### PR TITLE
Paginate admin panel lists

### DIFF
--- a/client/admin.html
+++ b/client/admin.html
@@ -93,27 +93,30 @@
 						<th>Status</th>
 						<th>Log in method</th>
 					</thead>
-					<tbody>
-						{{#each users}}
-							<tr>
-								<td>{{this.name}}</td>
-								<td>
-									{{this.email}}
-									{{#if this.verifiedEmail}}
-										<i class="fa fa-check" aria-hidden="true"></i>
-									{{else}}
-										<i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-									{{/if}}
-									{{#if this.admin}}
-										<i class="fa fa-asterisk" aria-hidden="true"></i>
-									{{/if}}
-								</td>
-								<td>{{this.status}}</td>
-								<td>{{this.loginMethods}}</td>
-							</tr>
-						{{/each}}
-					</tbody>
+					<tbody></tbody>
 				</table>
+				<p id="users-entries-status">Loading...</p>
+				<div class="center">
+					<button id="users-entries-previous" disabled><i class="fa fa-chevron-left"></i> Previous</button>
+					<button id="users-entries-next">Next <i class="fa fa-chevron-right"></i></button>
+				</div>
+				<template id="user-entry">
+					<tr>
+						<!-- Name -->
+						<td class="name"></td>
+						<!-- Email -->
+						<td class="email">
+							<span></span>
+							<i class="fa fa-check" title="Verified email" aria-hidden="true"></i>
+							<i class="fa fa-exclamation-triangle" title="Unverified email" aria-hidden="true"></i>
+							<i class="fa fa-asterisk" title="Admin" aria-hidden="true"></i>
+						</td>
+						<!-- Status -->
+						<td class="status"></td>
+						<!-- Login method(s) -->
+						<td class="login-method"></td>
+					</tr>
+				</template>
 			</section>
 			<section id="applicants">
 				<h2>Applicants</h2>

--- a/client/admin.html
+++ b/client/admin.html
@@ -131,8 +131,7 @@
 						<th>Email</th>
 						<th>Applicant type</th>
 						<th>
-							<select id="branchFilter">
-								<!--todo, make this prettier-->
+							<select id="branch-filter">
 								<option value="*">All types</option>
 								{{#each branchNames}}
 									<option value="{{this}}">{{this}}</span>
@@ -140,10 +139,10 @@
 							</select>
 						</th>
 						<th>
-							<select id="acceptedFilter">
-								<!--todo, make this prettier-->
-								<option value="accepted-false">Not accepted</option>
-								<option value="accepted-true">Accepted</option>
+							<select id="status-filter">
+								<option value="no-decision">No decision</option>
+								<option value="accepted">Accepted</option>
+								<!--<option value="rejected">Rejected</option>-->
 								<option value="*">All</option>
 							</select>
 						</th>
@@ -173,19 +172,15 @@
 						<td colspan="2">
 							<!-- Set status -->
 							<select class="status">
-								<option>No decision</option>
-								<option>Accepted</option>
+								<option value="no-decision">No decision</option>
+								<option value="accepted">Accepted</option>
 								<!--<option>Rejected</option>-->
 							</select>
 						</td>
 					</tr>
 					<tr class="details">
 						<td colspan="5">
-							<div class="applicantData">
-								<!--
-									<p><b>{{this.label}}</b> &rarr; {{this.value}} (<a href="/uploads/{{this.filename}}">Download</a>)</p>
-								-->
-							</div>
+							<div class="applicantData"></div>
 						</td>
 					</tr>
 				</template>

--- a/client/admin.html
+++ b/client/admin.html
@@ -148,56 +148,47 @@
 							</select>
 						</th>
 					</thead>
-					<tbody>
-						{{#each users}}
-							{{#if this.applied}}
-								<!--maybe query for each applied instead-->
-								<tr class="{{this.applicationBranch}} accepted-{{this.accepted}} applicantDiv">
-									<td><b>{{this.name}}</b></td>
-									<td>
-										{{#if this.teamName}}
-											<b class="teamName">{{this.teamName}}</b>
-										{{else}}
-											No Team
-										{{/if}}
-									</td>
-									<td>
-										{{this.email}}
-									</td>
-									<td>
-										{{this.applicationBranch}}
-									</td>
-									<td colspan="2">
-										<!--not sure if there's a better way to do it than bind id to button id-->
-										<button data-admin="{{../user.id}}" data-user="{{this._id}}" data-accepted="{{this.accepted}}" class="statusButton accepted-btn-{{this.accepted}}">
-											
-											{{#if this.accepted}}
-												Un-Accept
-											{{else}}
-												Accept
-											{{/if}}
-
-										</button>
-									</td>
-								</tr>
-								<tr class="{{this.applicationBranch}} accepted-{{this.accepted}} applicantDiv">
-									<td colspan="5">
-										<div class="applicantData">
-											{{#each this.applicationDataFormatted}}
-												{{#if this.filename}}
-													<p><b>{{this.label}}</b> &rarr; {{this.value}} (<a href="/uploads/{{this.filename}}">Download</a>)</p>
-												{{else}}
-													<p><b>{{this.label}}</b> &rarr; {{this.value}}</p>
-												{{/if}}
-											{{/each}}
-										</div>
-									</td>
-								</tr>
-								
-							{{/if}}
-						{{/each}}
-					</tbody>
+					<tbody></tbody>
 				</table>
+				<p id="applicants-entries-status">Loading...</p>
+				<div class="center">
+					<button id="applicants-entries-previous" disabled><i class="fa fa-chevron-left"></i> Previous</button>
+					<button id="applicants-entries-next">Next <i class="fa fa-chevron-right"></i></button>
+				</div>
+				<template id="applicants-entry">
+					<tr class="general">
+						<!-- Name -->
+						<td class="name"><b></b></td>
+						<!-- Team -->
+						<td class="team"></td>
+						<!-- Email -->
+						<td class="email">
+							<span></span>
+							<i class="fa fa-check" title="Verified email" aria-hidden="true"></i>
+							<i class="fa fa-exclamation-triangle" title="Unverified email" aria-hidden="true"></i>
+							<i class="fa fa-asterisk" title="Admin" aria-hidden="true"></i>
+						</td>
+						<!-- Application branch -->
+						<td class="branch"></td>
+						<td colspan="2">
+							<!-- Set status -->
+							<select class="status">
+								<option>No decision</option>
+								<option>Accepted</option>
+								<!--<option>Rejected</option>-->
+							</select>
+						</td>
+					</tr>
+					<tr class="details">
+						<td colspan="5">
+							<div class="applicantData">
+								<!--
+									<p><b>{{this.label}}</b> &rarr; {{this.value}} (<a href="/uploads/{{this.filename}}">Download</a>)</p>
+								-->
+							</div>
+						</td>
+					</tr>
+				</template>
 			</section>
 			<section id="settings">
 				<h2>Settings</h2>

--- a/client/css/admin.css
+++ b/client/css/admin.css
@@ -45,10 +45,13 @@ td.email.notverified > i.fa-exclamation-triangle {
 td.email.admin > i.fa-asterisk {
     display: inline;
 }
+td.team > b {
+    text-decoration: underline;
+}
 table thead {
     border-bottom: 2px solid #333030;
 }
-#users-entries-status {
+#users-entries-status, #applicants-entries-status {
     text-align: center;
 }
 #settings > .row {

--- a/client/css/admin.css
+++ b/client/css/admin.css
@@ -33,8 +33,23 @@ table td:last-child {
 #applicants table > tbody > tr:last-child {
     border-bottom: none;
 }
+td.email > i.fa {
+    display: none;
+}
+td.email.verified > i.fa-check {
+    display: inline;
+}
+td.email.notverified > i.fa-exclamation-triangle {
+    display: inline;
+}
+td.email.admin > i.fa-asterisk {
+    display: inline;
+}
 table thead {
     border-bottom: 2px solid #333030;
+}
+#users-entries-status {
+    text-align: center;
 }
 #settings > .row {
     text-align: center;

--- a/client/css/main.css
+++ b/client/css/main.css
@@ -9,10 +9,6 @@ main {
 	margin-bottom: 40px;
 }
 
-.teamName {
-	text-decoration: underline;
-}
-
 #sidebar > h1 {
 	margin: 15px 0 0 0;
 	text-align: center;

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -50,15 +50,15 @@ class UserEntries {
 		let query: { [index: string]: any } = {
 			offset: this.offset,
 			count: this.NODE_COUNT
-		}
+		};
 		let params = Object.keys(query)
-			.map(key => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
+			.map(key => `${encodeURIComponent(key)}=${encodeURIComponent(query[key])}`)
 			.join("&")
 			.replace(/%20/g, "+");
 		fetch(`/api/admin/users?${params}`, {
 			credentials: "same-origin",
 			method: "GET"
-		}).then(checkStatus).then(parseJSON).then((data: {
+		}).then(checkStatus).then(parseJSON).then((response: {
 			offset: number;
 			count: number;
 			total: number;
@@ -66,7 +66,7 @@ class UserEntries {
 		}) => {
 			for (let i = 0; i < this.NODE_COUNT; i++) {
 				let node = this.nodes[i];
-				let user = data.data[i];
+				let user = response.data[i];
 
 				if (user) {
 					node.style.display = "table-row";
@@ -90,25 +90,28 @@ class UserEntries {
 				}
 			}
 
-			if (data.offset <= 0) {
+			if (response.offset <= 0) {
 				this.previousButton.disabled = true;
 			}
 			else {
 				this.previousButton.disabled = false;
 			}
-			let upperBound = data.offset + data.count;
-			if (upperBound >= data.total) {
-				upperBound = data.total;
+			let upperBound = response.offset + response.count;
+			if (upperBound >= response.total) {
+				upperBound = response.total;
 				this.nextButton.disabled = true;
 			}
 			else {
 				this.nextButton.disabled = false;
 			}
-			let lowerBound = data.offset + 1;
-			if (data.data.length <= 0) {
+			let lowerBound = response.offset + 1;
+			if (response.data.length <= 0) {
 				lowerBound = 0;
 			}
-			status.textContent = `${lowerBound} – ${upperBound} of ${data.total.toLocaleString()}`;
+			status.textContent = `${lowerBound} – ${upperBound} of ${response.total.toLocaleString()}`;
+		}).catch(async err => {
+			console.error(err);
+			await sweetAlert("Oh no!", err.message, "error");
 		});
 	}
 
@@ -161,7 +164,7 @@ class ApplicantEntries {
 				let id = statusSelect.parentElement!.parentElement!.dataset.id!;
 				let formData = new FormData();
 				formData.append("status", statusSelect.value);
-			
+
 				fetch(`/api/user/${id}/status`, {
 					credentials: "same-origin",
 					method: "POST",
@@ -197,15 +200,15 @@ class ApplicantEntries {
 			count: this.NODE_COUNT,
 			applied: true,
 			...this.filter
-		}
+		};
 		let params = Object.keys(query)
-			.map(key => encodeURIComponent(key) + "=" + encodeURIComponent(query[key]))
+			.map(key => `${encodeURIComponent(key)}=${encodeURIComponent(query[key])}`)
 			.join("&")
 			.replace(/%20/g, "+");
 		fetch(`/api/admin/users?${params}`, {
 			credentials: "same-origin",
 			method: "GET"
-		}).then(checkStatus).then(parseJSON).then((data: {
+		}).then(checkStatus).then(parseJSON).then((response: {
 			offset: number;
 			count: number;
 			total: number;
@@ -214,8 +217,8 @@ class ApplicantEntries {
 			for (let i = 0; i < this.NODE_COUNT; i++) {
 				let generalNode = this.generalNodes[i];
 				let detailsNode = this.detailsNodes[i];
-				let user = data.data[i];
-				
+				let user = response.data[i];
+
 				if (user) {
 					generalNode.style.display = "table-row";
 					detailsNode.style.display = "table-row";
@@ -250,7 +253,7 @@ class ApplicantEntries {
 					while (dataSection.hasChildNodes()) {
 						dataSection.removeChild(dataSection.lastChild!);
 					}
-					for (let answer of user.applicationDataFormatted as { label: string, value: string, filename?: string }[]) {
+					for (let answer of user.applicationDataFormatted as { label: string; value: string; filename?: string }[]) {
 						let row = document.createElement("p");
 						let label = document.createElement("b");
 						label.textContent = answer.label;
@@ -273,25 +276,28 @@ class ApplicantEntries {
 				}
 			}
 
-			if (data.offset <= 0) {
+			if (response.offset <= 0) {
 				this.previousButton.disabled = true;
 			}
 			else {
 				this.previousButton.disabled = false;
 			}
-			let upperBound = data.offset + data.count;
-			if (upperBound >= data.total) {
-				upperBound = data.total;
+			let upperBound = response.offset + response.count;
+			if (upperBound >= response.total) {
+				upperBound = response.total;
 				this.nextButton.disabled = true;
 			}
 			else {
 				this.nextButton.disabled = false;
 			}
-			let lowerBound = data.offset + 1;
-			if (data.data.length <= 0) {
+			let lowerBound = response.offset + 1;
+			if (response.data.length <= 0) {
 				lowerBound = 0;
 			}
-			status.textContent = `${lowerBound} – ${upperBound} of ${data.total.toLocaleString()}`;
+			status.textContent = `${lowerBound} – ${upperBound} of ${response.total.toLocaleString()}`;
+		}).catch(async err => {
+			console.error(err);
+			await sweetAlert("Oh no!", err.message, "error");
 		});
 	}
 

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -155,6 +155,25 @@ class ApplicantEntries {
 			let node = document.importNode(applicantEntryTemplate.content, true);
 			applicantEntryTableBody.appendChild(node);
 			this.generalNodes.push(applicantEntryTableBody.querySelectorAll("tr.general")[i] as HTMLTableRowElement);
+			applicantEntryTableBody.querySelectorAll("tr.general")[i].querySelector("select.status")!.addEventListener("change", e => {
+				let statusSelect = e.target as HTMLSelectElement;
+				statusSelect.disabled = true;
+				let id = statusSelect.parentElement!.parentElement!.dataset.id!;
+				let formData = new FormData();
+				formData.append("status", statusSelect.value);
+			
+				fetch(`/api/user/${id}/status`, {
+					credentials: "same-origin",
+					method: "POST",
+					body: formData
+				}).then(checkStatus).then(parseJSON).then(async () => {
+					statusSelect.disabled = false;
+					this.load();
+				}).catch(async (err: Error) => {
+					await sweetAlert("Oh no!", err.message, "error");
+					statusSelect.disabled = false;
+				});
+			});
 			this.detailsNodes.push(applicantEntryTableBody.querySelectorAll("tr.details")[i] as HTMLTableRowElement);
 		}
 	}
@@ -201,6 +220,7 @@ class ApplicantEntries {
 					generalNode.style.display = "table-row";
 					detailsNode.style.display = "table-row";
 
+					generalNode.dataset.id = user._id;
 					generalNode.querySelector("td.name")!.textContent = user.name;
 					generalNode.querySelector("td.team")!.textContent = "";
 					if (user.teamName) {
@@ -223,7 +243,8 @@ class ApplicantEntries {
 						generalNode.querySelector("td.email")!.classList.add("admin");
 					}
 					generalNode.querySelector("td.branch")!.textContent = user.applicationBranch;
-					(generalNode.querySelector("select.status") as HTMLSelectElement).value = user.accepted ? "accepted" : "no-decision";
+					let statusSelect = generalNode.querySelector("select.status") as HTMLSelectElement;
+					statusSelect.value = user.accepted ? "accepted" : "no-decision";
 
 					let dataSection = detailsNode.querySelector("div.applicantData") as HTMLDivElement;
 					while (dataSection.hasChildNodes()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2589,9 +2589,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
-      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "supertest": "^3.0.0",
     "tslint": "^5.4.3",
     "tslint-language-service": "^0.9.6",
-    "typescript": "^2.4.1"
+    "typescript": "^2.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/server/app.ts
+++ b/server/app.ts
@@ -55,6 +55,8 @@ let apiRouter = express.Router();
 // API routes go here
 import {userRoutes} from "./routes/api/user";
 apiRouter.use("/user/:id", userRoutes);
+import {adminRoutes} from "./routes/api/admin";
+apiRouter.use("/admin", adminRoutes);
 import {settingsRoutes} from "./routes/api/settings";
 apiRouter.use("/settings", settingsRoutes);
 

--- a/server/routes/api/admin.ts
+++ b/server/routes/api/admin.ts
@@ -18,7 +18,21 @@ adminRoutes.route("/users").get(isAdmin, async (request, response) => {
 	if (isNaN(count) || count <= 0) {
 		count = 10;
 	}
-	let filter = request.query.applied === "true" ? { applied: true } : {};
+	let filter: any = {};
+	if (request.query.applied === "true") {
+		filter.applied = true;
+	}
+	if (request.query.branch) {
+		filter["$or"] = [{ "applicationBranch": request.query.branch }, { "confirmationBranch": request.query.branch }];
+	}
+	if (request.query.status === "no-decision") {
+		filter.applied = true;
+		filter.accepted = false;
+	}
+	if (request.query.status === "accepted") {
+		filter.applied = true;
+		filter.accepted = true;
+	}
 	let rawQuestions = await validateSchema(config.questions, "./config/questions.schema.json");
 
 	let teamIDNameMap: {

--- a/server/routes/api/admin.ts
+++ b/server/routes/api/admin.ts
@@ -1,0 +1,96 @@
+import * as express from "express";
+
+import {
+	isAdmin, config, validateSchema, formatSize
+} from "../../common";
+import {
+	User, Team
+} from "../../schema";
+
+export let adminRoutes = express.Router();
+
+adminRoutes.route("/users").get(isAdmin, async (request, response) => {
+	let offset = parseInt(request.query.offset, 10);
+	if (isNaN(offset) || offset < 0) {
+		offset = 0;
+	}
+	let count = parseInt(request.query.count, 10);
+	if (isNaN(count) || count <= 0) {
+		count = 10;
+	}
+	let filter = request.query.applied === "true" ? { applied: true } : {};
+	let rawQuestions = await validateSchema(config.questions, "./config/questions.schema.json");
+
+	let teamIDNameMap: {
+		[id: string]: string;
+	} = {};
+	(await Team.find()).forEach(team => {
+		teamIDNameMap[team._id.toString()] = team.teamName;
+	});
+
+	let total = await User.count(filter);
+	let results = (await User.find(filter).collation({ "locale": "en" }).sort({ name: "asc" }).skip(offset).limit(count).exec()).map(user => {
+		let loginMethods: string[] = [];
+		if (user.githubData && user.githubData.id) {
+			loginMethods.push("GitHub");
+		}
+		if (user.googleData && user.googleData.id) {
+			loginMethods.push("Google");
+		}
+		if (user.facebookData && user.facebookData.id) {
+			loginMethods.push("Facebook");
+		}
+		if (user.localData && user.localData.hash) {
+			loginMethods.push("Local");
+		}
+		let status: string = "Signed up";
+		if (user.applied) {
+			status = `Applied (${user.applicationBranch})`;
+		}
+		if (user.accepted) {
+			status = `Accepted (${user.applicationBranch})`;
+		}
+		if (user.attending) {
+			status = `Accepted (${user.applicationBranch}) / Attending (${user.confirmationBranch})`;
+		}
+		let questionsFromBranch = rawQuestions.find(branch => branch.name === user.applicationBranch);
+		let applicationDataFormatted: {"label": string; "value": string}[] = [];
+		if (questionsFromBranch) {
+			applicationDataFormatted = user.applicationData.map(question => {
+				let rawQuestion = questionsFromBranch!.questions.find(q => q.name === question.name);
+				// If there isn't schema information for this question return the raw name as the label
+				let label: string = rawQuestion ? rawQuestion.label : question.name;
+				
+				if (typeof question.value === "string") {
+					return { label, value: question.value };
+				}
+				else if (Array.isArray(question.value)) {
+					return { label, value: question.value.join(", ") };
+				}
+				else if (question.value === null) {
+					return { label, value: "N/A" };
+				}
+				else {
+					// Multer file
+					let file = question.value;
+					let formattedSize = formatSize(file.size);
+					return { label, value: `[${file.mimetype} | ${formattedSize}]: ${file.path}`, filename: file.filename };
+				}
+			});
+		}
+
+		return {
+			...user.toObject(),
+			"status": status,
+			"loginMethods": loginMethods.join(", "),
+			"applicationDataFormatted": applicationDataFormatted,
+			"teamName": user.teamId ? teamIDNameMap[user.teamId.toString()] : null
+		};
+	});
+	response.json({
+		offset,
+		count,
+		total,
+		data: results
+	});
+});

--- a/server/routes/api/admin.ts
+++ b/server/routes/api/admin.ts
@@ -23,6 +23,7 @@ adminRoutes.route("/users").get(isAdmin, async (request, response) => {
 		filter.applied = true;
 	}
 	if (request.query.branch) {
+		// tslint:disable-next-line:no-string-literal
 		filter["$or"] = [{ "applicationBranch": request.query.branch }, { "confirmationBranch": request.query.branch }];
 	}
 	if (request.query.status === "no-decision") {
@@ -74,7 +75,7 @@ adminRoutes.route("/users").get(isAdmin, async (request, response) => {
 				let rawQuestion = questionsFromBranch!.questions.find(q => q.name === question.name);
 				// If there isn't schema information for this question return the raw name as the label
 				let label: string = rawQuestion ? rawQuestion.label : question.name;
-				
+
 				if (typeof question.value === "string") {
 					return { label, value: question.value };
 				}

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -282,7 +282,7 @@ async function deleteApplicationBranchHandler(request: express.Request, response
 
 userRoutes.route("/status").post(isAdmin, uploadHandler.any(), async (request, response): Promise<void> => {
 	let user = await User.findById(request.params.id);
-	let status = request.body.status === "true";
+	let status = request.body.status;
 
 	if (!user) {
 		response.status(400).json({
@@ -290,7 +290,12 @@ userRoutes.route("/status").post(isAdmin, uploadHandler.any(), async (request, r
 		});
 		return;
 	}
-	user.accepted = status;
+	if (status === "no-decision") {
+		user.accepted = false;
+	}
+	else if (status === "accepted") {
+		user.accepted = true;
+	}
 
 	try {
 		await user.save();

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -263,7 +263,6 @@ export interface IAdminTemplate extends ICommonTemplate {
 		declinedUsers: number;
 	};
 	generalStatistics: StatisticEntry[];
-	users: any[];
 	metrics: {};
 	settings: {
 		application: {


### PR DESCRIPTION
Dramatically speeds up page load and interaction times for the admin panel by paginating user and applicant lists. Also simplifies code for accepting / unaccepting and adds the fundamentals required for future support for additional statuses (i.e. rejected).

Closes #105 
Closes #39 by adding tooltips to symbols