### PR TITLE
Fixes to errors encountered with 1.9.0 in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/server/common.ts
+++ b/server/common.ts
@@ -318,21 +318,14 @@ export async function setDefaultSettings() {
 		}
 	}
 }
-export async function getSetting<T>(name: string, createMissing: boolean = true, allowUndefined: boolean = false): Promise<T> {
+export async function getSetting<T>(name: string, createMissing: boolean = true): Promise<T> {
 	let setting = await Setting.findOne({ name });
-	if (!setting || !setting.value) {
-		if (setting && allowUndefined) {
-			// Caller explicitly allowed undefined to be returned as the value
-			return undefined!;
-		}
+	if (!setting) {
 		if (createMissing) {
 			await setDefaultSettings();
 			setting = await Setting.findOne({ name });
-			if (!setting || !setting.value) {
-				if (setting && allowUndefined) {
-					return undefined!;
-				}
-				throw new Error("Setting not created by setDefaultSettings()");
+			if (!setting) {
+				throw new Error(`Setting "${name}" not created by setDefaultSettings()`);
 			}
 		}
 		else {

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -471,7 +471,7 @@ templateRoutes.route("/admin").get(authenticateWithRedirect, async (request, res
 				"applicationBranches": applicationBranches,
 				"confirmationBranches": confirmationBranches
 			},
-			applicationToConfirmationMap: await getSetting<ApplicationToConfirmationMap>("applicationToConfirmation", true, true)
+			applicationToConfirmationMap: await getSetting<ApplicationToConfirmationMap>("applicationToConfirmation")
 		},
 		config: {
 			admins: config.admins.join(", "),
@@ -484,7 +484,10 @@ templateRoutes.route("/admin").get(authenticateWithRedirect, async (request, res
 	};
 	// Generate general statistics
 	(await User.find({ "applied": true })).forEach(statisticUser => {
-		let branchQuestions = rawQuestions.find(branch => branch.name === statisticUser.applicationBranch)!.questions;
+		let appliedBranch = rawQuestions.find(branch => branch.name === statisticUser.applicationBranch);
+		if (!appliedBranch) {
+			return;
+		}
 		let branchName = statisticUser.applicationBranch;
 		statisticUser.applicationData.forEach(question => {
 			if (question.value === null) {
@@ -499,7 +502,7 @@ templateRoutes.route("/admin").get(authenticateWithRedirect, async (request, res
 					values = question.value as string[];
 				}
 				for (let checkboxValue of values) {
-					let rawQuestion = branchQuestions.find(q => q.name === question.name)!;
+					let rawQuestion = appliedBranch!.questions.find(q => q.name === question.name)!;
 					let statisticEntry: StatisticEntry | undefined = templateData.generalStatistics.find(entry => entry.questionName === rawQuestion.label && entry.branch === branchName);
 
 					if (!statisticEntry) {


### PR DESCRIPTION
Reverts a change in `getSetting()` that wasn't ready for prime time and doesn't crash the app if a user's application branch doesn't match up with a branch with the same name from `questions.json`.