### PR TITLE
Don't minimize settings values

### DIFF
--- a/server/schema.ts
+++ b/server/schema.ts
@@ -199,6 +199,8 @@ export const Setting = mongoose.model<ISettingMongoose>("Setting", new mongoose.
 		unique: true
 	},
 	value: mongoose.Schema.Types.Mixed
+}, {
+	minimize: false
 }));
 
 // Handlebars templates


### PR DESCRIPTION
Should fix recent problems with the application to confirmation map setting being undefined because Mongoose doesn't save empty objects by default