### PR TITLE
Add application and confirmation counts for all active question branches

### DIFF
--- a/client/admin.html
+++ b/client/admin.html
@@ -66,6 +66,20 @@
 							<td>Declined users</td>
 							<td>{{numberFormat applicationStatistics.declinedUsers}}</td>
 						</tr>
+						<tr><th colspan="2">Applications by branch</th></tr>
+						{{#each applicationStatistics.applicationBranches}}
+							<tr>
+								<td>{{this.name}}</td>
+								<td>{{numberFormat this.count}}</td>
+							</tr>
+						{{/each}}
+						<tr><th colspan="2">Confirmations by branch</th></tr>
+						{{#each applicationStatistics.confirmationBranches}}
+							<tr>
+								<td>{{this.name}}</td>
+								<td>{{numberFormat this.count}}</td>
+							</tr>
+						{{/each}}
 					</tbody>
 				</table>
 				<table>

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -256,7 +256,7 @@ class ApplicantEntries {
 					for (let answer of user.applicationDataFormatted as { label: string; value: string; filename?: string }[]) {
 						let row = document.createElement("p");
 						let label = document.createElement("b");
-						label.textContent = answer.label;
+						label.innerHTML = answer.label;
 						row.appendChild(label);
 						row.appendChild(document.createTextNode(` → ${answer.value}`));
 						if (answer.filename) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -453,7 +453,19 @@ templateRoutes.route("/admin").get(authenticateWithRedirect, async (request, res
 			appliedUsers: await User.find({ "applied": true }).count(),
 			admittedUsers: await User.find({ "accepted": true }).count(),
 			attendingUsers: await User.find({ "attending": true }).count(),
-			declinedUsers: await User.find({ "accepted": true, "attending": false }).count()
+			declinedUsers: await User.find({ "accepted": true, "attending": false }).count(),
+			applicationBranches: await Promise.all(applicationBranches.map(async branch => {
+				return {
+					"name": branch,
+					"count": await User.find({ "applicationBranch": branch }).count()
+				};
+			})),
+			confirmationBranches: await Promise.all(confirmationBranches.map(async branch => {
+				return {
+					"name": branch,
+					"count": await User.find({ "confirmationBranch": branch }).count()
+				};
+			}))
 		},
 		generalStatistics: [] as StatisticEntry[],
 		metrics: {},

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -264,6 +264,14 @@ export interface IAdminTemplate extends ICommonTemplate {
 		admittedUsers: number;
 		attendingUsers: number;
 		declinedUsers: number;
+		applicationBranches: {
+			name: string;
+			count: number;
+		}[];
+		confirmationBranches: {
+			name: string;
+			count: number;
+		}[];
 	};
 	generalStatistics: StatisticEntry[];
 	metrics: {};


### PR DESCRIPTION
Adds a broken-down count of application and confirmation numbers by question branch to the admin panel statistics. Also fixes a bug where HTML was being treated as plain text in question labels found in the applicants section of the admin panel.