### PR TITLE
Fix redirect loop when trying to visit removed confirm branch.

### DIFF
--- a/.travis.d/build.sh
+++ b/.travis.d/build.sh
@@ -58,7 +58,7 @@ git_branch() {
 }
 
 git_branch_id() {
-    git_branch | sed 's/[^0-9a-zA-Z_-.]/-/g'
+    git_branch | sed 's/[^0-9a-zA-Z_.-]/-/g'
 }
 
 publish_project_container() {

--- a/client/index.html
+++ b/client/index.html
@@ -48,7 +48,7 @@
 							<p>Feel free to edit your RSVP at any time. However, once RSVPing closes on {{confirmationClose}}, you will not be able to edit it any further.</p>
 							<a class="btn" href="/confirm">Edit your confirmation</a>
 						{{else}}
-							<p>RSVPing closed on {{applicationClose}}.</p>
+							<p>RSVPing closed on {{confirmationClose}}.</p>
 						{{/if}}
 						<p>We look forward to seeing you!</p>
 

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -114,12 +114,20 @@ export enum ApplicationType {
 export async function timeLimited(request: express.Request, response: express.Response, next: express.NextFunction) {
 	let requestType: ApplicationType = request.url.match(/^\/apply/) ? ApplicationType.Application : ApplicationType.Confirmation;
 
+	let user = request.user as IUser;
+
 	let openBranches: (ApplicationBranch | ConfirmationBranch)[];
 	if (requestType === ApplicationType.Application) {
 		openBranches = await BranchConfig.getOpenBranches<ApplicationBranch>("Application");
+		if (user.applied) {
+			openBranches = openBranches.filter((b => b.name === user.applicationBranch));
+		}
 	}
 	else {
 		openBranches = await getOpenConfirmationBranches(request.user as IUser);
+		if (user.attending) {
+			openBranches = openBranches.filter((b => b.name === user.confirmationBranch));
+		}
 	}
 
 	if (openBranches.length > 0) {

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -292,8 +292,7 @@ function applicationHandler(requestType: ApplicationType): (request: express.Req
 				questionBranches = [user.applicationBranch.toLowerCase()];
 			}
 			else {
-				const branches = await Branches.BranchConfig
-					.getOpenBranches<Branches.ApplicationBranch>("Application");
+				const branches = await Branches.BranchConfig.getOpenBranches<Branches.ApplicationBranch>("Application");
 				questionBranches = branches.map(branch => branch.name.toLowerCase());
 			}
 		}
@@ -302,21 +301,16 @@ function applicationHandler(requestType: ApplicationType): (request: express.Req
 			const branches = await Branches.getOpenConfirmationBranches(user);
 			questionBranches = branches.map(branch => branch.name.toLowerCase());
 
-			let appliedBranch = (await Branches.BranchConfig
-				.loadBranchFromDB(user.applicationBranch)) as
-				Branches.ApplicationBranch;
+			let appliedBranch = (await Branches.BranchConfig.loadBranchFromDB(user.applicationBranch)) as Branches.ApplicationBranch;
 			if (appliedBranch) {
 				questionBranches = questionBranches.filter(branch => {
-					return !!appliedBranch!.confirmationBranches.find(confirm => {
+					return !!appliedBranch.confirmationBranches.find(confirm => {
 						return confirm.toLowerCase() === branch;
 					});
 				});
 			}
 
-			const userConfirm = user.confirmationBranch.toLowerCase();
-			if (user.attending
-				&& questionBranches.indexOf(userConfirm) !== -1
-			) {
+			if (user.attending && questionBranches.indexOf(user.confirmationBranch.toLowerCase()) !== -1) {
 				questionBranches = [user.confirmationBranch.toLowerCase()];
 			}
 		}

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -259,61 +259,92 @@ templateRoutes.route("/team").get(authenticateWithRedirect, async (request, resp
 	response.send(teamTemplate(templateData));
 });
 
-templateRoutes.route("/apply").get(authenticateWithRedirect, timeLimited, applicationHandler);
-templateRoutes.route("/confirm").get(authenticateWithRedirect, timeLimited, applicationHandler);
+templateRoutes.route("/apply").get(
+	authenticateWithRedirect,
+	timeLimited,
+	applicationHandler(ApplicationType.Application)
+);
+templateRoutes.route("/confirm").get(
+	authenticateWithRedirect,
+	timeLimited,
+	applicationHandler(ApplicationType.Confirmation)
+);
 
-async function applicationHandler(request: express.Request, response: express.Response) {
-	let requestType: ApplicationType = request.url.match(/^\/apply/) ? ApplicationType.Application : ApplicationType.Confirmation;
-
-	let user = request.user as IUser;
-	if (requestType === ApplicationType.Application && user.accepted) {
-		response.redirect("/confirm");
-		return;
-	}
-	if (requestType === ApplicationType.Confirmation && (!user.accepted || !user.applied)) {
-		response.redirect("/apply");
-		return;
-	}
-	if (requestType === ApplicationType.Application && user.applied) {
-		response.redirect(`/apply/${encodeURIComponent(user.applicationBranch.toLowerCase())}`);
-		return;
-	}
-	else if (requestType === ApplicationType.Confirmation && user.attending) {
-		response.redirect(`/confirm/${encodeURIComponent(user.confirmationBranch.toLowerCase())}`);
-		return;
-	}
-
-	let questionBranches: (Branches.ApplicationBranch | Branches.ConfirmationBranch)[] = [];
-
-	// Filter to only show application / confirmation branches
-	if (requestType === ApplicationType.Application) {
-		questionBranches = await Branches.BranchConfig.getOpenBranches<Branches.ApplicationBranch>("Application");
-	}
-	// Additionally selectively allow confirmation branches based on what the user applied as
-	else if (requestType === ApplicationType.Confirmation) {
-		questionBranches = await Branches.getOpenConfirmationBranches(user);
-
-		let appliedBranch = (await Branches.BranchConfig.loadBranchFromDB(user.applicationBranch)) as Branches.ApplicationBranch;
-		if (appliedBranch) {
-			questionBranches = questionBranches.filter(branch => appliedBranch!.confirmationBranches.indexOf(branch.name) !== -1);
+function applicationHandler(requestType: ApplicationType): (request: express.Request, response: express.Response) => Promise<void> {
+	return async (request: express.Request, response: express.Response) => {
+		// TODO: fix branch names so they have a machine ID and human label
+		let user = request.user as IUser;
+		if (requestType === ApplicationType.Application && user.accepted) {
+			response.redirect("/confirm");
+			return;
 		}
-	}
+		if (requestType === ApplicationType.Confirmation && !user.accepted) {
+			response.redirect("/apply");
+			return;
+		}
 
-	// If there's only one path, redirect to that
-	if (questionBranches.length === 1) {
-		response.redirect(`/${requestType === ApplicationType.Application ? "apply" : "confirm"}/${encodeURIComponent(questionBranches[0].name.toLowerCase())}`);
-		return;
-	}
-	let templateData: IRegisterBranchChoiceTemplate = {
-		siteTitle: config.eventName,
-		user,
-		settings: {
-			teamsEnabled: await getSetting<boolean>("teamsEnabled"),
-			qrEnabled: await getSetting<boolean>("qrEnabled")
-		},
-		branches: questionBranches.map(branch => branch.name)
+		let questionBranches: string[] = [];
+
+		// Filter to only show application / confirmation branches
+		// NOTE: this assumes the user is still able to apply as this type at this point
+		if (requestType === ApplicationType.Application) {
+			if (user.applied) {
+				questionBranches = [user.applicationBranch.toLowerCase()];
+			}
+			else {
+				const branches = await Branches.BranchConfig
+					.getOpenBranches<Branches.ApplicationBranch>("Application");
+				questionBranches = branches.map(branch => branch.name.toLowerCase());
+			}
+		}
+		// Additionally selectively allow confirmation branches based on what the user applied as
+		else if (requestType === ApplicationType.Confirmation) {
+			const branches = await Branches.getOpenConfirmationBranches(user);
+			questionBranches = branches.map(branch => branch.name.toLowerCase());
+
+			let appliedBranch = (await Branches.BranchConfig
+				.loadBranchFromDB(user.applicationBranch)) as
+				Branches.ApplicationBranch;
+			if (appliedBranch) {
+				questionBranches = questionBranches.filter(branch => {
+					return !!appliedBranch!.confirmationBranches.find(confirm => {
+						return confirm.toLowerCase() === branch;
+					});
+				});
+			}
+
+			const userConfirm = user.confirmationBranch.toLowerCase();
+			if (user.attending
+				&& questionBranches.indexOf(userConfirm) !== -1
+			) {
+				questionBranches = [user.confirmationBranch.toLowerCase()];
+			}
+		}
+
+		// If there's only one path, redirect to that
+		if (questionBranches.length === 1) {
+			const uriBranch = encodeURIComponent(questionBranches[0]);
+			const redirPath = requestType === ApplicationType.Application ? "apply" : "confirm";
+			response.redirect(`/${redirPath}/${uriBranch}`);
+			return;
+		}
+		let templateData: IRegisterBranchChoiceTemplate = {
+			siteTitle: config.eventName,
+			user,
+			settings: {
+				teamsEnabled: await getSetting<boolean>("teamsEnabled"),
+				qrEnabled: await getSetting<boolean>("qrEnabled")
+			},
+			branches: questionBranches
+		};
+
+		if (requestType === ApplicationType.Application) {
+			response.send(preregisterTemplate(templateData));
+		}
+		else {
+			response.send(preconfirmTemplate(templateData));
+		}
 	};
-	response.send(requestType === ApplicationType.Application ? preregisterTemplate(templateData) : preconfirmTemplate(templateData));
 }
 
 templateRoutes.route("/apply/:branch").get(authenticateWithRedirect, timeLimited, applicationBranchHandler);


### PR DESCRIPTION
To reproduce bug: Apply and Confirm for event, then in settings disallow that confirmation branch from that application branch. Finally attempt to visit `/confirm`.