### PR TITLE
Display open / close times on dashboard for all branches

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -45,7 +45,7 @@
 						<p>Application type: <b>{{user.applicationBranch}}</b></p>
 						<p>Confirmation type: <b>{{user.confirmationBranch}}</b></p>
 						{{#if confirmationStatus.areOpen}}
-							<p>Feel free to edit your RSVP at any time. However, once RSVPing closes on {{confirmationClose}}, you will not be able to edit it any further.</p>
+							<p>Feel free to edit your RSVP at any time. However, once RSVPing closes on {{confirmationClose}}, you will not be able to edit it anymore.</p>
 							<a class="btn" href="/confirm">Edit your confirmation</a>
 						{{else}}
 							<p>RSVPing closed on {{confirmationClose}}.</p>
@@ -69,7 +69,7 @@
 								<p>RSVPing will open on {{confirmationOpen}}.</p>
 							{{/if}}
 							{{#if confirmationStatus.afterClose}}
-								<p>RSVPs closed on {{confirmationClose}}. Unfortunately, since you did not RSVP in time, you will be unable to attend {{siteTitle}}.</p>
+								<p>RSVPs closed on {{confirmationClose}}. Thanks for your interest in {{siteTitle}} &mdash; we hope to see you next time!</p>
 							{{/if}}
 						{{/if}}
 					{{else if user.applied}}
@@ -91,7 +91,7 @@
 								<p>Applications are currently closed and will open on {{applicationOpen}}.</p>
 							{{/if}}
 							{{#if applicationStatus.afterClose}}
-								<p>Applications closed on {{applicationClose}}. Unfortunately, because you did not submit an application, you will not be eligible for {{siteTitle}}.</p>
+								<p>Applications closed on {{applicationClose}}. Thanks for your interest in {{siteTitle}} &mdash; we hope to see you next time!</p>
 							{{/if}}
 						{{/if}}
 					{{/if}}

--- a/client/index.html
+++ b/client/index.html
@@ -60,16 +60,43 @@
 						{{#if confirmationStatus.areOpen}}
 							<p>You've been accepted but you still need to RSVP!</p>
 							<p>Application type: <b>{{user.applicationBranch}}</b></p>
-							<p>If you do not RSVP before {{confirmationClose}}, you will not be able to attend {{siteTitle}}!</p>
+							{{#ifCond allConfirmationTimes.length 1}}
+								<p>If you do not RSVP before {{confirmationClose}}, you will not be able to attend {{siteTitle}}!</p>
+							{{else}}
+								<p>If you do not RSVP before the deadline for your confirmation type, you will not be able to attend {{siteTitle}}!</p>
+								<ul>
+									{{#each allConfirmationTimes}}
+										<li><strong>{{this.name}}</strong>: {{this.open}} until {{this.close}}</li>
+									{{/each}}
+								</ul>
+							{{/ifCond}}
 							<a class="btn" href="/confirm">Confirm your attendance</a>
 						{{else}}
 							<p>You've been accepted!</p>
 							<p>Application type: <b>{{user.applicationBranch}}</b></p>
 							{{#if confirmationStatus.beforeOpen}}
-								<p>RSVPing will open on {{confirmationOpen}}.</p>
+								{{#ifCond allConfirmationTimes.length 1}}
+									<p>RSVPing will open on {{confirmationOpen}}.</p>
+								{{else}}
+									<p>RSVPing will be open during the following times:</p>
+									<ul>
+										{{#each allConfirmationTimes}}
+											<li><strong>{{this.name}}</strong>: {{this.open}} until {{this.close}}</li>
+										{{/each}}
+									</ul>
+								{{/ifCond}}
 							{{/if}}
 							{{#if confirmationStatus.afterClose}}
-								<p>RSVPs closed on {{confirmationClose}}. Thanks for your interest in {{siteTitle}} &mdash; we hope to see you next time!</p>
+								{{#ifCond allConfirmationTimes.length 1}}
+									<p>RSVPs closed on {{confirmationClose}}. Thanks for your interest in {{siteTitle}} &mdash; we hope to see you next time!</p>
+								{{else}}
+									<p>RSVPs closed at the following times. Thanks for your interest in {{siteTitle}} &mdash; we hope to see you next time!</p>
+									<ul>
+										{{#each allConfirmationTimes}}
+											<li><strong>{{this.name}}</strong>: {{this.close}}</li>
+										{{/each}}
+									</ul>
+								{{/ifCond}}
 							{{/if}}
 						{{/if}}
 					{{else if user.applied}}
@@ -84,14 +111,41 @@
 					{{else}}
 						{{#if applicationStatus.areOpen}}
 							<p>You still need to complete your application!</p>
-							<p>If you do not complete your application before {{applicationClose}}, you will not be considered for {{siteTitle}}!</p>
+							{{#ifCond allApplicationTimes.length 1}}
+								<p>If you do not complete your application before {{applicationClose}}, you will not be considered for {{siteTitle}}!</p>
+							{{else}}
+								<p>If you do not complete your application before the following times, you will not be considered for {{siteTitle}}:</p>
+								<ul>
+									{{#each allApplicationTimes}}
+										<li><strong>{{this.name}}</strong>: {{this.close}}</li>
+									{{/each}}
+								</ul>
+							{{/ifCond}}
 							<a class="btn" href="/apply">Complete your application</a>
 						{{else}}
 							{{#if applicationStatus.beforeOpen}}
-								<p>Applications are currently closed and will open on {{applicationOpen}}.</p>
+								{{#ifCond allApplicationTimes.length 1}}
+									<p>Applications are currently closed and will open on {{applicationOpen}}.</p>
+								{{else}}
+									<p>Applications are currently closed and will open at the following times:</p>
+									<ul>
+										{{#each allApplicationTimes}}
+											<li><strong>{{this.name}}</strong>: {{this.open}}</li>
+										{{/each}}
+									</ul>
+								{{/ifCond}}
 							{{/if}}
 							{{#if applicationStatus.afterClose}}
-								<p>Applications closed on {{applicationClose}}. Thanks for your interest in {{siteTitle}} &mdash; we hope to see you next time!</p>
+								{{#ifCond allApplicationTimes.length 1}}
+									<p>Applications closed on {{applicationClose}}. Thanks for your interest in {{siteTitle}} &mdash; we hope to see you next time!</p>
+								{{else}}
+									<p>Applications closed at the following times. Thanks for your interest in {{siteTitle}} &mdash; we hope to see you next time!</p>
+									<ul>
+										{{#each allApplicationTimes}}
+											<li><strong>{{this.name}}</strong>: {{this.close}}</li>
+										{{/each}}
+									</ul>
+								{{/ifCond}}
 							{{/if}}
 						{{/if}}
 					{{/if}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -203,14 +203,27 @@ templateRoutes.route("/").get(authenticateWithRedirect, async (request, response
 			beforeOpen: applicationOpenDate ? moment().isBefore(applicationOpenDate) : true,
 			afterClose: applicationCloseDate ? moment().isAfter(applicationCloseDate) : false
 		},
-
 		confirmationOpen: formatMoment(confirmationOpenDate),
 		confirmationClose: formatMoment(confirmationCloseDate),
 		confirmationStatus: {
 			areOpen: confirmationOpenDate && confirmationCloseDate ? moment().isBetween(confirmationOpenDate, confirmationCloseDate) : false,
 			beforeOpen: confirmationOpenDate ? moment().isBefore(confirmationOpenDate) : true,
 			afterClose: confirmationCloseDate ? moment().isAfter(confirmationCloseDate) : false
-		}
+		},
+		allApplicationTimes: applyBranches.map(branch => {
+			return {
+				name: branch.name,
+				open: formatMoment(moment(branch.open)),
+				close: formatMoment(moment(branch.close))
+			};
+		}),
+		allConfirmationTimes: confirmBranches.map(branch => {
+			return {
+				name: branch.name,
+				open: formatMoment(moment(branch.open)),
+				close: formatMoment(moment(branch.close))
+			};
+		})
 	};
 	response.send(indexTemplate(templateData));
 });

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -187,6 +187,17 @@ templateRoutes.route("/").get(authenticateWithRedirect, async (request, response
 		}
 		return "(No branches configured)";
 	}
+	function formatMoments(open: moment.Moment, close: moment.Moment): { open: string; close: string } {
+		let openString = formatMoment(open);
+		let closeString = formatMoment(close);
+		if (!moment().isBetween(open, close)) {
+			closeString += " (Closed)";
+		}
+		return {
+			open: openString,
+			close: closeString
+		};
+	}
 
 	let templateData: IIndexTemplate = {
 		siteTitle: config.eventName,
@@ -213,15 +224,13 @@ templateRoutes.route("/").get(authenticateWithRedirect, async (request, response
 		allApplicationTimes: applyBranches.map(branch => {
 			return {
 				name: branch.name,
-				open: formatMoment(moment(branch.open)),
-				close: formatMoment(moment(branch.close))
+				...formatMoments(moment(branch.open), moment(branch.close))
 			};
 		}),
 		allConfirmationTimes: confirmBranches.map(branch => {
 			return {
 				name: branch.name,
-				open: formatMoment(moment(branch.open)),
-				close: formatMoment(moment(branch.close))
+				...formatMoments(moment(branch.open), moment(branch.close))
 			};
 		})
 	};

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -279,6 +279,16 @@ export interface IIndexTemplate extends ICommonTemplate {
 		beforeOpen: boolean;
 		afterClose: boolean;
 	};
+	allApplicationTimes: {
+		name: string;
+		open: string;
+		close: string;
+	}[];
+	allConfirmationTimes: {
+		name: string;
+		open: string;
+		close: string;
+	}[];
 }
 export interface ITeamTemplate extends ICommonTemplate {
 	team?: ITeamMongoose | null;


### PR DESCRIPTION
* Softens the "you didn't apply or confirm on time" message
* Fixes a bug that reported the current time as the open / close date when all branches were configured as no-op
* Shows a list of open / close times by branch when more than one application or confirmation branch is available. Otherwise, it just shows the open / close time with no branch label like before.

Fixes #174 