### PR TITLE
Fix rolling deadline display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -227,7 +227,7 @@ templateRoutes.route("/").get(authenticateWithRedirect, async (request, response
 				...formatMoments(moment(branch.open), moment(branch.close))
 			};
 		}),
-		allConfirmationTimes: confirmBranches.map(branch => {
+		allConfirmationTimes: confirmTimesArr.map(branch => {
 			return {
 				name: branch.name,
 				...formatMoments(moment(branch.open), moment(branch.close))


### PR DESCRIPTION
Previously used the raw times from `questions.json` and ignored the object that already merged in confirmation deadlines sourced from the DB.