### PR TITLE
Fix morgan status code coloring bug

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -43,13 +43,13 @@ morgan.format("hackgt", (tokens, request, response) => {
 	if (response.statusCode >= 500) {
 		statusColorizer = chalk.red;
 	}
-	if (response.statusCode >= 400) {
+	else if (response.statusCode >= 400) {
 		statusColorizer = chalk.yellow;
 	}
-	if (response.statusCode >= 300) {
+	else if (response.statusCode >= 300) {
 		statusColorizer = chalk.cyan;
 	}
-	if (response.statusCode >= 200) {
+	else if (response.statusCode >= 200) {
 		statusColorizer = chalk.green;
 	}
 


### PR DESCRIPTION
Previously, all status codes would be marked green because the conditionals should have been `else if`s instead of plain `if`s