### PR TITLE
Implement custom email subjects

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 HackGT
+Copyright (c) 2018 HackGT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -140,4 +140,4 @@ If you have some time and want to help us out with development, thank you! You c
 
 ## License
 
-Copyright &copy; 2017 HackGT. Released under the MIT license. See [LICENSE](LICENSE) for more information.
+Copyright &copy; 2018 HackGT. Released under the MIT license. See [LICENSE](LICENSE) for more information.

--- a/client/admin.html
+++ b/client/admin.html
@@ -220,6 +220,10 @@
 				<h2>Settings</h2>
 
 				<form method="post" data-action="/">
+					<div class="row center">
+						<input type="submit" class="btn" value="Save" />
+					</div>
+
 					<div class="row" style="text-align: center;">
 						<div class="col-6">
 							<label for="teams-enabled">Enable teams?</label>
@@ -364,7 +368,7 @@
 					</div>
 
 					<div class="row center">
-						<input type="submit" class="btn" value="Update" />
+						<input type="submit" class="btn" value="Save" />
 					</div>
 				</form>
 			</section>

--- a/client/admin.html
+++ b/client/admin.html
@@ -304,6 +304,9 @@
 									{{/each}}
 								</optgroup>
 							</select>
+							<label for="email-subject">Subject:</label>
+							<input type="text" id="email-subject" />
+							<label for="email-content">Body:</label>
 							<textarea id="email-content"></textarea>
 							<h5>Rendered HTML and text:</h5>
 							<section id="email-rendered"></section>

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -647,14 +647,23 @@ function parseDateTime(dateTime: string) {
 	let digits = dateTime.split(/\D+/).map(num => parseInt(num, 10));
 	return new Date(digits[0], digits[1] - 1, digits[2], digits[3], digits[4], digits[5] || 0, digits[6] || 0);
 }
-let settingsUpdateButton = document.querySelector("#settings input[type=submit]") as HTMLInputElement;
+let settingsUpdateButtons = document.querySelectorAll("#settings input[type=submit]") as NodeListOf<HTMLInputElement>;
 let settingsForm = document.querySelector("#settings form") as HTMLFormElement;
-settingsUpdateButton.addEventListener("click", e => {
+for (let i = 0; i < settingsUpdateButtons.length; i++) {
+	settingsUpdateButtons[i].addEventListener("click", settingsUpdate);
+}
+function settingsUpdateButtonDisabled(disabled: boolean) {
+	for (let i = 0; i < settingsUpdateButtons.length; i++) {
+		settingsUpdateButtons[i].disabled = disabled;
+	}
+}
+
+function settingsUpdate(e: MouseEvent) {
 	if (!settingsForm.checkValidity() || !settingsForm.dataset.action) {
 		return;
 	}
 	e.preventDefault();
-	settingsUpdateButton.disabled = true;
+	settingsUpdateButtonDisabled(true);
 
 	let teamsEnabledData = new FormData();
 	teamsEnabledData.append("enabled", (document.getElementById("teams-enabled") as HTMLInputElement).checked ? "true" : "false");
@@ -742,9 +751,9 @@ settingsUpdateButton.addEventListener("click", e => {
 		window.location.reload();
 	}).catch(async (err: Error) => {
 		await sweetAlert("Oh no!", err.message, "error");
-		settingsUpdateButton.disabled = false;
+		settingsUpdateButtonDisabled(false);
 	});
-});
+}
 
 //
 // Graphs

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -570,6 +570,7 @@ sendAcceptancesButton.addEventListener("click", async e => {
 declare let SimpleMDE: any;
 
 const emailTypeSelect = document.getElementById("email-type") as HTMLSelectElement;
+const emailSubject = document.getElementById("email-subject") as HTMLInputElement;
 let emailRenderedArea: HTMLElement | ShadowRoot = document.getElementById("email-rendered") as HTMLElement;
 if (document.head.attachShadow) {
 	// Browser supports Shadow DOM
@@ -616,8 +617,9 @@ async function emailTypeChange(): Promise<void> {
 
 	// Load editor content via AJAX
 	try {
-		let content = (await fetch(`/api/settings/email_content/${emailTypeSelect.value}`, { credentials: "same-origin" }).then(checkStatus).then(parseJSON)).content as string;
-		markdownEditor.value(content);
+		let emailSettings: { subject: string; content: string } = await fetch(`/api/settings/email_content/${emailTypeSelect.value}`, { credentials: "same-origin" }).then(checkStatus).then(parseJSON);
+		emailSubject.value = emailSettings.subject;
+		markdownEditor.value(emailSettings.content);
 	}
 	catch {
 		markdownEditor.value("Couldn't retrieve email content");
@@ -700,6 +702,7 @@ settingsUpdateButton.addEventListener("click", e => {
 	}
 
 	let emailContentData = new FormData();
+	emailContentData.append("subject", emailSubject.value);
 	emailContentData.append("content", markdownEditor.value());
 
 	const defaultOptions: RequestInit = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -208,7 +208,7 @@
       "integrity": "sha512-HG4pUK/fTrGY3FerMlINxK74MxdAxkCRYrp5AM+oJ2jLcK0jWUi64ZV15JKwDR4TYLIxrT3y9SVnEWcLPbC/YA==",
       "dev": true,
       "requires": {
-        "moment": "2.18.1"
+        "moment": "2.21.0"
       }
     },
     "@types/mongodb": {
@@ -2198,16 +2198,16 @@
       }
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "moment-timezone": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
       "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
       "requires": {
-        "moment": "2.18.1"
+        "moment": "2.21.0"
       }
     },
     "mongodb": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "json-schema-to-typescript": "^4.4.0",
     "json2csv": "^3.7.3",
     "marked": "^0.3.9",
-    "moment": "^2.18.1",
+    "moment": "^2.21.0",
     "moment-timezone": "^0.5.13",
     "mongoose": "^4.10.3",
     "morgan": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "TBD",
   "main": "server/app.js",
   "scripts": {

--- a/server/common.ts
+++ b/server/common.ts
@@ -376,6 +376,11 @@ import * as marked from "marked";
 const striptags = require("striptags");
 import { IUser, Team, IFormItem } from "./schema";
 
+export const defaultEmailSubjects = {
+	apply: `[${config.eventName}] - Thank you for applying!`,
+	accept: `[${config.eventName}] - You've been accepted!`,
+	attend: `[${config.eventName}] - Thank you for RSVPing!`
+};
 interface IMailObject {
 	to: string;
 	from: string;


### PR DESCRIPTION
Allows admins to customize the subjects of the post-apply, post-accept, and post-RSVP emails. Also adds a second save button to the top of the settings page for ergonomics.

Closes #130 