### PR TITLE
Move ip and user to fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "description": "Powerful and extensible registration system for hackathons and other large events",
   "main": "server/app.js",
   "scripts": {

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -280,15 +280,14 @@ export function trackEvent(action: string, request: express.Request, user?: stri
 	let tags = {
 		action,
 		url: request.path,
-		ip: request.ip,
-		user,
 		...data
 	};
 	let metricsEvent: HackGTMetrics = {
 		hackgtmetricsversion: 1,
 		serviceName: `registration-${config.eventName.replace(/[^a-zA-Z0-9]/g, "")}-${action}`,
 		values: {
-			value: 1
+			user,
+			ip: request.ip
 		},
 		tags
 	};


### PR DESCRIPTION
InfluxDB recommends high cardinality data go in fields, and we may want to run queries on this data that require it is stored in a field.