### PR TITLE
Add support for sending ad hoc batch emails

### DIFF
--- a/client/admin.html
+++ b/client/admin.html
@@ -36,6 +36,7 @@
 				<a href="#users" class="btn">Users</a>
 				<a href="#applicants" class="btn">Applicants</a>
 				<a href="#settings" class="btn">Settings</a>
+				<a href="#emails" class="btn">Emails</a>
 			</nav>
 
 			<section id="statistics">
@@ -411,6 +412,42 @@
 						<input type="submit" class="btn" value="Save" />
 					</div>
 				</form>
+			</section>
+			<section id="emails">
+				<h2>Batch Emails - BE CAREFUL</h2>
+				<select id="email-branch-filter">
+					<option value="*">All accounts</option>
+					<option value="na">Not Applied</option>
+					<optgroup label="Applicant Type">
+						{{#each settings.branches.application}}
+						<option value="application-{{this.name}}">{{this.name}}</option>
+						{{/each}}
+						{{#each settings.branches.confirmation}}
+						<option value="confirmation-{{this.name}}">{{this.name}}</option>
+						{{/each}}
+					</optgroup>
+				</select>
+				<select id="email-status-filter">
+				</select>
+
+				<input type="text" id="batch-email-subject" placeholder="Email Subject"/>
+				<textarea id="batch-email-content"></textarea>
+				<h5>Rendered HTML and text:</h5>
+				<section id="batch-email-rendered"></section>
+
+				<h5>List of variables:</h5>
+				<ul>
+					<li><strong>\{{eventName}}</strong>: The name of the event, configured by the <code>eventName</code> key-value pair in the <code>config.json</code> and displayed at the top of the page.</li>
+					<li><strong>\{{email}}</strong>: The user's email as reported by them or a 3rd party OAuth provider (i.e. Google, GitHub, Facebook).</li>
+					<li><strong>\{{name}}</strong>: The user's name as reported by them or a 3rd party OAuth provider (i.e. Google, GitHub, Facebook).</li>
+					<li><strong>\{{teamName}}</strong>: The user's team name if teams are enabled and the user has joined a team. Otherwise, will output <code>Teams not enabled</code> or <code>No team created or joined</code> respectively.</li>
+					<li><strong>\{{applicationBranch}}</strong>: The question branch name that the user applied / was accepted to.</li>
+					<li><strong>\{{confirmationBranch}}</strong>: The question branch name that the user RSVPed to.</li>
+					<li><strong>\{{application.<code>question-name</code>}}</strong>: Prints the user's response to the application question with the specified name from <code>questions.json</code>. Note that the question name is different from the question label. <a href="https://github.com/HackGT/registration/blob/master/server/config/questions.json" target="_blank">See the GitHub project</a> for details. Will print <code>N/A</code> if not yet answered.</li>
+					<li><strong>\{{confirmation.<code>question-name</code>}}</strong>: Prints the user's response to the confirmation question with the specified name from <code>questions.json</code>.</li>
+					<li><strong>\{{reimbursementAmount}}</strong>: A string representing how much a user should be reimbursed for.</li>
+				</ul>
+				<button id="sendEmail">Send Email</button>
 			</section>
 		{{/sidebar}}
 	</body>

--- a/client/admin.html
+++ b/client/admin.html
@@ -35,8 +35,8 @@
 				<a href="#statistics" class="btn">Statistics</a>
 				<a href="#users" class="btn">Users</a>
 				<a href="#applicants" class="btn">Applicants</a>
-				<a href="#settings" class="btn">Settings</a>
 				<a href="#emails" class="btn">Emails</a>
+				<a href="#settings" class="btn">Settings</a>
 			</nav>
 
 			<section id="statistics">
@@ -447,7 +447,9 @@
 					<li><strong>\{{confirmation.<code>question-name</code>}}</strong>: Prints the user's response to the confirmation question with the specified name from <code>questions.json</code>.</li>
 					<li><strong>\{{reimbursementAmount}}</strong>: A string representing how much a user should be reimbursed for.</li>
 				</ul>
-				<button id="sendEmail">Send Email</button>
+				<div class="row center">
+					<button id="sendEmail">Send Email</button>
+				</div>
 			</section>
 		{{/sidebar}}
 	</body>

--- a/client/admin.html
+++ b/client/admin.html
@@ -414,7 +414,7 @@
 				</form>
 			</section>
 			<section id="emails">
-				<h2>Batch Emails - BE CAREFUL</h2>
+				<h2>Batch Emails</h2>
 				<select id="email-branch-filter">
 					<option value="*">All accounts</option>
 					<option value="na">Not Applied</option>

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -69,10 +69,10 @@ async function batchEmailTypeChange(): Promise<void> {
 		let [, type ] = batchEmailBranchFilterSelect.value.match(/^(application|confirmation)-(.*)$/)!;
 		// Only confirmation branches have no-submission option since confirmation is manually assigned
 		if (type === "confirmation") {
-			let noSubmission = new Option("Have not submitted", "no-submission");
+			let noSubmission = new Option("Have not submitted (Confirmation)", "no-submission");
 			batchEmailStatusFilterSelect.add(noSubmission);
 		}
-		let submitted = new Option("Submitted", "submitted");
+		let submitted = new Option(`Submitted (${type.charAt(0).toUpperCase() + type.slice(1)})`, "submitted");
 		batchEmailStatusFilterSelect.add(submitted);
 	}
 }

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -69,10 +69,10 @@ async function batchEmailTypeChange(): Promise<void> {
 		let [, type ] = batchEmailBranchFilterSelect.value.match(/^(application|confirmation)-(.*)$/)!;
 		// Only confirmation branches have no-submission option since confirmation is manually assigned
 		if (type === "confirmation") {
-			let noSubmission = new Option('Have not submitted', 'no-submission');
+			let noSubmission = new Option("Have not submitted", "no-submission");
 			batchEmailStatusFilterSelect.add(noSubmission);
 		}
-		let submitted = new Option('Submitted', 'submitted');
+		let submitted = new Option("Submitted", "submitted");
 		batchEmailStatusFilterSelect.add(submitted);
 	}
 }
@@ -891,7 +891,7 @@ for (let i = 0; i < data.length; i++) {
 let emailBranchFilter = document.getElementById("email-branch-filter") as HTMLInputElement;
 let emailStatusFilter = document.getElementById("email-status-filter") as HTMLInputElement;
 let sendEmailButton = document.getElementById("sendEmail") as HTMLButtonElement;
-let batchEmailSubject = document.getElementById('batch-email-subject') as HTMLInputElement;
+let batchEmailSubject = document.getElementById("batch-email-subject") as HTMLInputElement;
 let batchEmailEditor = new SimpleMDE({ element: document.getElementById("batch-email-content")! });
 let batchEmailRenderedArea: HTMLElement | ShadowRoot = document.getElementById("batch-email-rendered") as HTMLElement;
 if (document.head.attachShadow) {
@@ -939,9 +939,8 @@ sendEmailButton.addEventListener("click", () => {
 		credentials: "same-origin",
 		method: "POST",
 		body: content
-	}).then(checkStatus).then(parseJSON).then((result: string) => {
-		console.log(result);
+	}).then(checkStatus).then(parseJSON).then((result: {success: boolean; count: number} ) => {
 		sendEmailButton.disabled = false;
-		sweetAlert("Dank!", "Successfully sent out your batch email!", "success");
+		sweetAlert("Success!", `Successfully sent ${result.count} email(s)!`, "success");
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Powerful and extensible registration system for hackathons and other large events",
   "main": "server/app.js",
   "scripts": {

--- a/server/common.ts
+++ b/server/common.ts
@@ -396,11 +396,12 @@ export interface IMailObject {
 	html: string;
 	text: string;
 }
-export async function sendMailAsync(mail: IMailObject): Promise<void>  {
-	await sendgrid.send(mail);
+// Union types don't work well with overloaded method resolution in Typescript so we split into two methods
+export async function sendMailAsync(mail: IMailObject)  {
+	return sendgrid.send(mail);
 }
-export async function sendBatchMailAsync(mail: IMailObject[]): Promise<void>  {
-	await sendgrid.send(mail);
+export async function sendBatchMailAsync(mail: IMailObject[]) {
+	return sendgrid.send(mail);
 }
 export function sanitize(input?: string): string {
 	if (!input || typeof input !== "string") {

--- a/server/common.ts
+++ b/server/common.ts
@@ -389,7 +389,7 @@ export const defaultEmailSubjects = {
 	preConfirm: `[${config.eventName}] - Application Update`,
 	attend: `[${config.eventName}] - Thank you for RSVPing!`
 };
-interface IMailObject {
+export interface IMailObject {
 	to: string;
 	from: string;
 	subject: string;
@@ -399,8 +399,11 @@ interface IMailObject {
 export async function sendMailAsync(mail: IMailObject): Promise<void>  {
 	await sendgrid.send(mail);
 }
-export function sanitize(input: string): string {
-	if (typeof input !== "string") {
+export async function sendBatchMailAsync(mail: IMailObject[]): Promise<void>  {
+	await sendgrid.send(mail);
+}
+export function sanitize(input?: string): string {
+	if (!input || typeof input !== "string") {
 		return "";
 	}
 	return input.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -458,16 +461,12 @@ export async function renderEmailHTML(markdown: string, user: IUser): Promise<st
 
 	// Interpolate and sanitize variables
 	markdown = markdown.replace(/{{eventName}}/g, sanitize(config.eventName));
-	if (user.reimbursementAmount) {
-		markdown = markdown.replace(/{{reimbursementAmount}}/g, sanitize(user.reimbursementAmount));
-	} else {
-		markdown = markdown.replace(/{{reimbursementAmount}}/g, "");
-	}
+	markdown = markdown.replace(/{{reimbursementAmount}}/g, sanitize(user.reimbursementAmount));
 	markdown = markdown.replace(/{{email}}/g, sanitize(user.email));
 	markdown = markdown.replace(/{{name}}/g, sanitize(user.name));
 	markdown = markdown.replace(/{{teamName}}/g, sanitize(teamName));
 	markdown = markdown.replace(/{{applicationBranch}}/g, sanitize(user.applicationBranch));
-	markdown = markdown.replace(/{{confirmationBranch}}/g, sanitize(user.confirmationBranch || ""));
+	markdown = markdown.replace(/{{confirmationBranch}}/g, sanitize(user.confirmationBranch));
 	markdown = markdown.replace(/{{application\.([a-zA-Z0-9\- ]+)}}/g, (match, name: string) => {
 		let question = user.applicationData.find(data => data.name === name);
 		return formatFormItem(question);

--- a/server/routes/api/settings.ts
+++ b/server/routes/api/settings.ts
@@ -263,23 +263,6 @@ settingsRoutes.route("/email_content/:type")
 		}
 	});
 
-settingsRoutes.route("/email_content/batch_email/rendered")
-	.post(isAdmin, uploadHandler.any(), async (request, response) => {
-		// Endpoint for generalized email, without templating for user args; meant for batch sending email
-		try {
-			let markdown: string = request.body.content;
-			let html: string = await renderEmailHTML(markdown, request.user as IUser);
-			let text: string = await renderEmailText(html, request.user as IUser, true);
-			response.json({ html, text });
-		}
-		catch (err) {
-			console.error(err);
-			response.status(500).json({
-				"error": "An error occurred while rendering the email content"
-			});
-		}
-	});
-
 settingsRoutes.route("/email_content/:type/rendered")
 	.post(isAdmin, uploadHandler.any(), async (request, response) => {
 		try {
@@ -340,6 +323,7 @@ settingsRoutes.route("/send_batch_email")
 		}
 		console.log(`Sent ${emails.length} batch emails requested by ${(request.user as IUser).email}`);
 		return response.json({
-			"success": true
+			"success": true,
+			"count": emails.length
 		});
 	});

--- a/server/routes/api/settings.ts
+++ b/server/routes/api/settings.ts
@@ -1,7 +1,7 @@
 import * as express from "express";
 
 import {
-	getSetting, updateSetting, renderEmailHTML, renderEmailText, defaultEmailSubjects
+	getSetting, updateSetting, renderEmailHTML, renderEmailText, defaultEmailSubjects, sendBatchMailAsync, config, IMailObject
 } from "../../common";
 import {
 	isAdmin, uploadHandler
@@ -263,6 +263,23 @@ settingsRoutes.route("/email_content/:type")
 		}
 	});
 
+settingsRoutes.route("/email_content/batch_email/rendered")
+	.post(isAdmin, uploadHandler.any(), async (request, response) => {
+		// Endpoint for generalized email, without templating for user args; meant for batch sending email
+		try {
+			let markdown: string = request.body.content;
+			let html: string = await renderEmailHTML(markdown, request.user as IUser);
+			let text: string = await renderEmailText(html, request.user as IUser, true);
+			response.json({ html, text });
+		}
+		catch (err) {
+			console.error(err);
+			response.status(500).json({
+				"error": "An error occurred while rendering the email content"
+			});
+		}
+	});
+
 settingsRoutes.route("/email_content/:type/rendered")
 	.post(isAdmin, uploadHandler.any(), async (request, response) => {
 		try {
@@ -278,4 +295,51 @@ settingsRoutes.route("/email_content/:type/rendered")
 				"error": "An error occurred while rendering the email content"
 			});
 		}
+	});
+
+settingsRoutes.route("/send_batch_email")
+	.post(isAdmin, uploadHandler.any(), async (request, response) => {
+		let filter = JSON.parse(request.body.filter);
+		let subject = request.body.subject;
+		let markdownContent = request.body.markdownContent;
+		if (typeof filter !== "object") {
+			return response.status(400).json({
+				"error": `Your query '${filter}' is not a valid MongoDB query`
+			});
+		} else if (subject === "" || subject === undefined) {
+			return response.status(400).json({
+				"error": "Can't have an empty subject!"
+			});
+		} else if (markdownContent === "" || markdownContent === undefined) {
+			return response.status(400).json({
+				"error": "Can't have an empty email body!"
+			});
+		}
+
+		let users = await User.find(filter);
+		let emails: IMailObject[] = [];
+		for (let user of users) {
+			let html: string = await renderEmailHTML(markdownContent, user);
+			let text: string = await renderEmailText(html, user, true);
+
+			emails.push({
+				from: config.email.from,
+				to: user.email,
+				subject,
+				html,
+				text
+			});
+		}
+		try {
+			await sendBatchMailAsync(emails);
+		} catch (e) {
+			console.error(e);
+			return response.status(500).json({
+				"error": "Error sending email!"
+			});
+		}
+		console.log(`Sent ${emails.length} batch emails requested by ${(request.user as IUser).email}`);
+		return response.json({
+			"success": true
+		});
 	});


### PR DESCRIPTION
We can slice by different groups:

* All users with an account
* Users that haven't submitted an application

Per Application Branch:
* Users that have submitted that application branch

Per Confirmation Branch:
* Users that have not submitted their confirmation
* Users that have submitted their confirmation

Closes #190 
Closes #193 
Based on #195 by @mjkaufer.