### PR TITLE
Add ability to query for multiple users by list of IDs

### DIFF
--- a/api.graphql
+++ b/api.graphql
@@ -11,7 +11,7 @@ type Query {
   # All the users in the database, useful for polling for new user information.
   # This is paginated, n is the number of results, and last_id is the last ID
   # seen from the latest page retrieved, if you want the first page leave this out.
-  users(pagination_token: ID, n: Int!, filter: UserFilter): [User!]!
+  users(pagination_token: ID, n: Int!, filter: UserFilter, ids: [String]): [User!]!
   # Search for users by name and email
   search_user(search: String!, use_regex: Boolean = false, offset: Int!, n: Int!, filter: UserFilter): SearchResult!
   # Simplified search_user that can be forwarded correctly from checkin2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Powerful and extensible registration system for hackathons and other large events",
   "main": "server/app.js",
   "scripts": {

--- a/server/routes/api/graphql.ts
+++ b/server/routes/api/graphql.ts
@@ -40,9 +40,15 @@ const resolvers: IResolver = {
 					$gt: args.pagination_token
 				}
 			} : {};
+			const uuidQuery = args.ids ? {
+				uuid: {
+					$in: args.ids
+				}
+			} : {};
 			const allUsers = await User
 				.find({
 					...lastIdQuery,
+					...uuidQuery,
 					...userFilterToMongo(args.filter)
 				})
 				.limit(args.n);


### PR DESCRIPTION
Added an optional IDs argument for the users query to allow for querying by a list of user IDs. Needed for sponsorship portal, which will fetch user information from registration based on IDs. 