### PR TITLE
Add graphql query for Sponsorship Portal use

### DIFF
--- a/api.graphql
+++ b/api.graphql
@@ -12,6 +12,8 @@ type Query {
   # This is paginated, n is the number of results, and last_id is the last ID
   # seen from the latest page retrieved, if you want the first page leave this out.
   users(pagination_token: ID, n: Int!, filter: UserFilter, ids: [String]): [User!]!
+  # Query for sponsorship portal to fetch users by a list of user IDs
+  users_sportal(n: Int!, offset: Int!, filter: UserFilter, ids: [String!]!): SearchResult!
   # Search for users by name and email
   search_user(search: String!, use_regex: Boolean = false, offset: Int!, n: Int!, filter: UserFilter): SearchResult!
   # Simplified search_user that can be forwarded correctly from checkin2

--- a/server/routes/api/graphql.ts
+++ b/server/routes/api/graphql.ts
@@ -55,6 +55,27 @@ const resolvers: IResolver = {
 
 			return Promise.all(allUsers.map(userRecordToGraphql));
 		},
+		users_sportal: async (prev, args) => {
+			const total = await User
+				.find(userFilterToMongo(args.filter))
+				.where('uuid')
+				.in(args.ids)
+				.count();
+			const results = await User
+				.find(userFilterToMongo(args.filter))
+				.where('uuid')
+				.in(args.ids)
+				.limit(args.n)
+				.skip(args.offset)
+				.exec();
+
+			return {
+				offset: args.offset,
+				count: results.length,
+				total,
+				users: Promise.all(results.map(userRecordToGraphql))
+			};
+		},
 		search_user: searchUser,
 		search_user_simple: async (prev, args) => {
 			return (await searchUser(prev, args)).users;


### PR DESCRIPTION
Added a graphql query that takes in a list of IDs, an offset, and the number of results to return. This makes implementing pagination for sponsorship portal easier, since currently there's no way of searching by a list of IDs, knowing how many total results there are, and being able to go straight to a certain page. 