### PR TITLE
Fixes for stat graphs in admin panel

### DIFF
--- a/client/admin.html
+++ b/client/admin.html
@@ -14,9 +14,9 @@
 		<script src="/node_modules/whatwg-fetch/fetch.js"></script>
 		<script src="/node_modules/sweetalert2/dist/sweetalert2.min.js"></script>
 		<script src="/node_modules/easymde/dist/easymde.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
 		<script src="https://use.fontawesome.com/efaca8fe24.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.6.0/Chart.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js"></script>
 		<script src="/js/common.js"></script>
 		<script>
 			window.data = [
@@ -90,7 +90,7 @@
 						{{#each generalStatistics}}
 							<tr>
 								<td>
-									<h5>{{this.questionName}} ({{this.branch}})</h5>
+									<h5>{{this.questionLabel}} ({{this.branch}})</h5>
 									<canvas id="chart-{{@index}}"></canvas>
 								</td>
 							</tr>

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -842,6 +842,7 @@ for (let i = 0; i < data.length; i++) {
 		continue;
 	}
 
+	const MAX_SIZE = 50;
 	new Chart(context, {
 		"type": "bar",
 		"data": {
@@ -874,12 +875,34 @@ for (let i = 0; i < data.length; i++) {
 						"stepSize": 1,
 						"autoSkip": false,
 						"minRotation": 0,
-						"maxRotation": 60
+						"maxRotation": 60,
+						"callback": (value: string, index: number, values: string[]) => {
+							if (value.length > MAX_SIZE) {
+								value = value.substr(0, MAX_SIZE) + "...";
+							}
+							return value;
+						}
 					},
 					"gridLines": {
 						"zeroLineColor": color
 					}
 				}]
+			},
+			"tooltips": {
+				"callbacks": {
+					"title": (tooltipItem: any, graphData: any) => {
+						let title: string = graphData.labels[tooltipItem[0].index];
+						let titleWithLineBreaks = "";
+						while (title.length > 0) {
+							titleWithLineBreaks += title.substring(0, MAX_SIZE);
+							if (title.length > MAX_SIZE) {
+								titleWithLineBreaks += "\n";
+							}
+							title = title.substring(MAX_SIZE);
+						}
+						return titleWithLineBreaks;
+					}
+				}
 			}
 		}
 	});

--- a/client/js/admin.ts
+++ b/client/js/admin.ts
@@ -847,7 +847,7 @@ for (let i = 0; i < data.length; i++) {
 		"data": {
 			"labels": data[i].responses.map(response => response.response),
 			"datasets": [{
-				"label": data[i].questionName,
+				"label": "Count",
 				"data": data[i].responses.map(response => response.count),
 				"backgroundColor": Array(data[i].responses.length).fill(color)
 			}]
@@ -861,7 +861,7 @@ for (let i = 0; i < data.length; i++) {
 					"ticks": {
 						"fontColor": color,
 						"beginAtZero": true,
-						"callback": (value: number) => value % 1 === 0 ? value : undefined // Only integers
+						"precision": 0 // Only integers
 					},
 					"gridLines": {
 						"zeroLineColor": color
@@ -872,7 +872,9 @@ for (let i = 0; i < data.length; i++) {
 					"ticks": {
 						"fontColor": color,
 						"stepSize": 1,
-						"autoSkip": false
+						"autoSkip": false,
+						"minRotation": 0,
+						"maxRotation": 60
 					},
 					"gridLines": {
 						"zeroLineColor": color

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "Powerful and extensible registration system for hackathons and other large events",
   "main": "server/app.js",
   "scripts": {

--- a/server/common.ts
+++ b/server/common.ts
@@ -410,6 +410,9 @@ export function sanitize(input?: string): string {
 	}
 	return input.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
+export function removeTags(input: string): string {
+	return striptags(input);
+}
 
 let renderer = new marked.Renderer();
 let singleLineRenderer = new marked.Renderer();
@@ -515,7 +518,7 @@ export async function renderEmailText(markdown: string, user: IUser, markdownRen
 	});
 	html = $.html();
 
-	let text: string = striptags(html);
+	let text = removeTags(html);
 	// Reverse sanitization
 	return text.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">");
 }

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -8,7 +8,7 @@ import * as uuid from "uuid/v4";
 
 import {
 	STATIC_ROOT, STORAGE_ENGINE,
-	config, getSetting, renderMarkdown
+	config, getSetting, renderMarkdown, removeTags
 } from "../common";
 import {
 	authenticateWithRedirect, isAdmin,
@@ -751,14 +751,15 @@ templateRoutes.route("/admin").get(authenticateWithRedirect, async (request, res
 					if (!rawQuestion) {
 						continue;
 					}
-					let rawQuestionLabel = rawQuestion.label;
-					let statisticEntry: StatisticEntry | undefined = templateData.generalStatistics.find(entry => entry.questionName === rawQuestionLabel && entry.branch === appliedBranch.name);
+					let questionName = rawQuestion.name;
+					let statisticEntry: StatisticEntry | undefined = templateData.generalStatistics.find(entry => entry.questionName === questionName && entry.branch === appliedBranch.name);
 
 					if (!statisticEntry) {
 						statisticEntry = {
-							"questionName": rawQuestionLabel,
-							"branch": statisticUser.applicationBranch,
-							"responses": []
+							questionName,
+							questionLabel: removeTags(rawQuestion.label),
+							branch: statisticUser.applicationBranch,
+							responses: []
 						};
 						templateData.generalStatistics.push(statisticEntry);
 					}
@@ -769,8 +770,8 @@ templateRoutes.route("/admin").get(authenticateWithRedirect, async (request, res
 					}
 					else {
 						statisticEntry.responses.push({
-							"response": checkboxValue,
-							"count": 1
+							response: removeTags(checkboxValue),
+							count: 1
 						});
 					}
 				}

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -324,13 +324,14 @@ export interface IRegisterTemplate extends ICommonTemplate {
 	unauthenticated: boolean;
 }
 export interface ResponseCount {
-	"response": string;
-	"count": number;
+	response: string;
+	count: number;
 }
 export interface StatisticEntry {
-	"questionName": string;
-	"branch": string;
-	"responses": ResponseCount[];
+	questionName: string;
+	questionLabel: string;
+	branch: string;
+	responses: ResponseCount[];
 }
 export interface IAdminTemplate extends ICommonTemplate {
 	applicationStatistics: {


### PR DESCRIPTION
- Updates graph tooltips to display more relevant information (and line break after 50 characters)
- Strip rendered markdown HTML from graph titles and categories
- Fix question ordering. Questions should now be organized by branch (e.g. Participant, Mentor) and then by question in the exact same order that they appear in `questions.json` and the actual application. Previously, questions could appear in random orders and branches were sorted alphabetically.
- Speed up question sorting dramatically (~400% on my local machine with very few users -- could be even more in production) by eliminating DB accesses from the sorting loop.

Fixes #148 
Fixes #149 