### PR TITLE
Add configurable word and character limits to questions

### DIFF
--- a/client/js/application.ts
+++ b/client/js/application.ts
@@ -126,3 +126,21 @@ for (let i = 0; i < inputsWithOther.length; i++) {
 		}
 	});
 }
+
+let wordCountInputs = document.querySelectorAll("[data-max-word-count], [data-min-word-count]") as NodeListOf<HTMLInputElement | HTMLTextAreaElement>;
+for (let i = 0; i < wordCountInputs.length; i++) {
+	wordCountInputs[i].addEventListener("input", e => {
+		let target = e.target as HTMLInputElement | HTMLTextAreaElement;
+		let correspondingLabel = document.querySelector(`label[for="${target.id}"] > .current-count`);
+		if (!correspondingLabel) return;
+
+		let { maxWordCount, minWordCount } = target.dataset;
+		if (!maxWordCount && !minWordCount) return;
+
+		let wordCount = target.value.trim().split(/\s+/).length;
+		if (target.value.trim().length === 0) {
+			wordCount = 0;
+		}
+		correspondingLabel.textContent = `(${wordCount.toLocaleString()} word${wordCount === 1 ? "" : "s"})`;
+	});
+}

--- a/client/js/application.ts
+++ b/client/js/application.ts
@@ -130,12 +130,12 @@ for (let i = 0; i < inputsWithOther.length; i++) {
 let wordCountInputs = document.querySelectorAll("[data-max-word-count], [data-min-word-count]") as NodeListOf<HTMLInputElement | HTMLTextAreaElement>;
 for (let i = 0; i < wordCountInputs.length; i++) {
 	wordCountInputs[i].addEventListener("input", e => {
-		let target = e.target as HTMLInputElement | HTMLTextAreaElement;
-		let correspondingLabel = document.querySelector(`label[for="${target.id}"] > .current-count`);
-		if (!correspondingLabel) return;
+		const target = e.target as HTMLInputElement | HTMLTextAreaElement;
+		const correspondingLabel = document.querySelector(`label[for="${target.id}"] > .current-count`);
+		if (!correspondingLabel) { return; }
 
-		let { maxWordCount, minWordCount } = target.dataset;
-		if (!maxWordCount && !minWordCount) return;
+		const { maxWordCount, minWordCount } = target.dataset;
+		if (!maxWordCount && !minWordCount) { return; }
 
 		let wordCount = target.value.trim().split(/\s+/).length;
 		if (target.value.trim().length === 0) {

--- a/client/partials/form.html
+++ b/client/partials/form.html
@@ -33,9 +33,23 @@
 			</fieldset>
 		{{/ifCond}}
 	{{else}}
-		<label for="form-{{this.name}}" class="{{required this.required}}">{{{this.label}}}</label>
+		<label for="form-{{this.name}}" class="{{required this.required}}">
+			{{{this.label}}}
+			{{#if this.minWordCount}}
+				<small>(At least {{this.minWordCount}} words)&nbsp;</small>
+			{{/if}}
+			{{#if this.maxWordCount}}
+				<small>(Max {{this.maxWordCount}} words)&nbsp;</small>
+			{{/if}}
+			{{#if this.minCharacterCount}}
+				<small>(At least {{this.minCharacterCount}} characters)&nbsp;</small>
+			{{/if}}
+			{{#if this.maxCharacterCount}}
+				<small>(Max {{this.maxCharacterCount}} characters)&nbsp;</small>
+			{{/if}}
+		</label>
 		{{#ifCond this.type "textarea"}}
-			<textarea name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}}>{{this.value}}</textarea>
+			<textarea name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}} minlength="{{this.minCharacterCount}}" maxlength="{{this.maxCharacterCount}}">{{this.value}}</textarea>
 		{{else}}
 			{{#ifCond this.type "file"}}
 				{{#if this.value}}
@@ -45,7 +59,7 @@
 					<input type="file" name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}} />
 				{{/if}}
 			{{else}}
-				<input type="{{this.type}}" name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}} value="{{this.value}}" />
+				<input type="{{this.type}}" name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}} minlength="{{this.minCharacterCount}}" maxlength="{{this.maxCharacterCount}}" value="{{this.value}}" />
 			{{/ifCond}}
 		{{/ifCond}}
 	{{/if}}

--- a/client/partials/form.html
+++ b/client/partials/form.html
@@ -36,20 +36,21 @@
 		<label for="form-{{this.name}}" class="{{required this.required}}">
 			{{{this.label}}}
 			{{#if this.minWordCount}}
-				<small>(At least {{this.minWordCount}} words)&nbsp;</small>
+				<small>(At least {{this.minWordCount}} words)</small>
 			{{/if}}
 			{{#if this.maxWordCount}}
-				<small>(Max {{this.maxWordCount}} words)&nbsp;</small>
+				<small>(Max {{this.maxWordCount}} words)</small>
 			{{/if}}
 			{{#if this.minCharacterCount}}
-				<small>(At least {{this.minCharacterCount}} characters)&nbsp;</small>
+				<small>(At least {{this.minCharacterCount}} characters)</small>
 			{{/if}}
 			{{#if this.maxCharacterCount}}
-				<small>(Max {{this.maxCharacterCount}} characters)&nbsp;</small>
+				<small>(Max {{this.maxCharacterCount}} characters)</small>
 			{{/if}}
+			<small class="current-count"></small>
 		</label>
 		{{#ifCond this.type "textarea"}}
-			<textarea name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}} minlength="{{this.minCharacterCount}}" maxlength="{{this.maxCharacterCount}}">{{this.value}}</textarea>
+			<textarea name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}} minlength="{{this.minCharacterCount}}" maxlength="{{this.maxCharacterCount}}" data-max-word-count="{{this.maxWordCount}}" data-min-word-count="{{this.minWordCount}}">{{this.value}}</textarea>
 		{{else}}
 			{{#ifCond this.type "file"}}
 				{{#if this.value}}
@@ -59,7 +60,7 @@
 					<input type="file" name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}} />
 				{{/if}}
 			{{else}}
-				<input type="{{this.type}}" name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}} minlength="{{this.minCharacterCount}}" maxlength="{{this.maxCharacterCount}}" value="{{this.value}}" />
+				<input type="{{this.type}}" name="{{this.name}}" id="form-{{this.name}}" placeholder="{{this.placeholder}}" {{required this.required}} minlength="{{this.minCharacterCount}}" maxlength="{{this.maxCharacterCount}}" data-max-word-count="{{this.maxWordCount}}" data-min-word-count="{{this.minWordCount}}" value="{{this.value}}" />
 			{{/ifCond}}
 		{{/ifCond}}
 	{{/if}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registration",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "description": "Powerful and extensible registration system for hackathons and other large events",
   "main": "server/app.js",
   "scripts": {

--- a/server/common.ts
+++ b/server/common.ts
@@ -82,7 +82,7 @@ class Config implements IConfig.Main {
 		}
 		if (config.secrets) {
 			for (let key of Object.keys(config.secrets) as (keyof IConfig.Secrets)[]) {
-				this.secrets[key] = config.secrets[key];
+				(this.secrets as any)[key] = config.secrets[key];
 			}
 		}
 		if (config.email) {
@@ -92,7 +92,7 @@ class Config implements IConfig.Main {
 		}
 		if (config.server) {
 			for (let key of Object.keys(config.server) as (keyof IConfig.Server)[]) {
-				this.server[key] = config.server[key];
+				(this.server as any)[key] = config.server[key];
 			}
 		}
 		if (config.admins) {

--- a/server/config/questions.schema.json
+++ b/server/config/questions.schema.json
@@ -77,6 +77,18 @@
                                 },
                                 "required": {
                                     "type": "boolean"
+                                },
+                                "maxWordCount": {
+                                    "type": "number"
+                                },
+                                "minWordCount": {
+                                    "type": "number"
+                                },
+                                "maxCharacterCount": {
+                                    "type": "number"
+                                },
+                                "minCharacterCount": {
+                                    "type": "number"
                                 }
                             },
                             "required": [

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -164,7 +164,10 @@ function postApplicationBranchHandler(anonymous: boolean): (request: express.Req
 			if (question.maxCharacterCount && getQuestion("").length > question.maxCharacterCount) {
 				return reportError(`Your response to "${question.label}" cannot exceed ${question.maxCharacterCount} characters`);
 			}
-			let wordCount = getQuestion("").split(/\s+/).length;
+			let wordCount = getQuestion("").trim().split(/\s+/).length;
+			if (getQuestion("").trim().length === 0) {
+				wordCount = 0;
+			}
 			let wordCountPlural = wordCount === 1 ? "" : "s";
 			if (question.minWordCount && wordCount < question.minWordCount) {
 				return reportError(`Your response to "${question.label}" must contain at least ${question.minWordCount} words (currently has ${wordCount} word${wordCountPlural})`);

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -164,6 +164,14 @@ function postApplicationBranchHandler(anonymous: boolean): (request: express.Req
 			if (question.maxCharacterCount && getQuestion("").length > question.maxCharacterCount) {
 				return reportError(`Your response to "${question.label}" cannot exceed ${question.maxCharacterCount} characters`);
 			}
+			let wordCount = getQuestion("").split(/\s+/).length;
+			let wordCountPlural = wordCount === 1 ? "" : "s";
+			if (question.minWordCount && wordCount < question.minWordCount) {
+				return reportError(`Your response to "${question.label}" must contain at least ${question.minWordCount} words (currently has ${wordCount} word${wordCountPlural})`);
+			}
+			if (question.maxWordCount && wordCount > question.maxWordCount) {
+				return reportError(`Your response to "${question.label}" cannot exceed ${question.maxWordCount} words (currently has ${wordCount} word${wordCountPlural})`);
+			}
 
 			if ((question.type === "select" || question.type === "radio") && Array.isArray(getQuestion<unknown>(question.name)) && question.hasOther) {
 				// "Other" option selected

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -38,37 +38,45 @@ let postApplicationBranchErrorHandler: express.ErrorRequestHandler = (err, reque
 };
 
 // We don't use canUserModify here, instead check for admin
-registrationRoutes.route("/:branch").post(
-	isAdmin,
-	postParser,
-	uploadHandler.any(),
-	postApplicationBranchErrorHandler,
-	postApplicationBranchHandler(true)
-);
+registrationRoutes.route("/:branch")
+	.post(
+		isAdmin,
+		postParser,
+		uploadHandler.any(),
+		postApplicationBranchErrorHandler,
+		postApplicationBranchHandler(true)
+	);
 
-userRoutes.route("/application/:branch").post(
-	isUserOrAdmin,
-	canUserModify,
-	postParser,
-	uploadHandler.any(),
-	postApplicationBranchErrorHandler,
-	postApplicationBranchHandler(false)
-).delete(
-	isUserOrAdmin,
-	canUserModify,
-	deleteApplicationBranchHandler);
-userRoutes.route("/confirmation/:branch").post(
-	isUserOrAdmin,
-	canUserModify,
-	postParser,
-	uploadHandler.any(),
-	postApplicationBranchErrorHandler,
-	postApplicationBranchHandler(false)
-).delete(
-	isUserOrAdmin,
-	canUserModify,
-	deleteApplicationBranchHandler
-);
+userRoutes.route("/application/:branch")
+	.post(
+		isUserOrAdmin,
+		canUserModify,
+		postParser,
+		uploadHandler.any(),
+		postApplicationBranchErrorHandler,
+		postApplicationBranchHandler(false)
+	)
+	.delete(
+		isUserOrAdmin,
+		canUserModify,
+		deleteApplicationBranchHandler
+	);
+
+userRoutes.route("/confirmation/:branch")
+	.post(
+		isUserOrAdmin,
+		canUserModify,
+		postParser,
+		uploadHandler.any(),
+		postApplicationBranchErrorHandler,
+		postApplicationBranchHandler(false)
+	)
+	.delete(
+		isUserOrAdmin,
+		canUserModify,
+		deleteApplicationBranchHandler
+	);
+
 function postApplicationBranchHandler(anonymous: boolean): (request: express.Request, response: express.Response) => Promise<void> {
 	return async (request, response) => {
 		let user: Model<IUser>;
@@ -111,6 +119,21 @@ function postApplicationBranchHandler(anonymous: boolean): (request: express.Req
 		let unchangedFiles: string[] = [];
 		let errored: boolean = false; // Used because .map() can't be broken out of
 		let rawData: (IFormItem | null)[] = questionBranch.questions.map(question => {
+			function reportError(message: string): null {
+				errored = true;
+				response.status(400).json({
+					"error": message
+				});
+				return null;
+			}
+			function getQuestion<T>(defaultValue?: T): T {
+				let value = request.body[question.name] as T;
+				if (defaultValue) {
+					return value || defaultValue;
+				}
+				return value;
+			}
+
 			if (errored) {
 				return null;
 			}
@@ -120,7 +143,7 @@ function postApplicationBranchHandler(anonymous: boolean): (request: express.Req
 				&& user.applicationData != undefined
 				&& user.applicationData.some(entry => entry.name === question.name && !!entry.value);
 
-			if (question.required && !request.body[question.name] && !files.find(file => file.fieldname === question.name)) {
+			if (question.required && !getQuestion<unknown>() && !files.find(file => file.fieldname === question.name)) {
 				// Required field not filled in
 				if (preexistingFile) {
 					let previousValue = user.applicationData!.find(entry => entry.name === question.name && !!entry.value)!.value as Express.Multer.File;
@@ -132,31 +155,34 @@ function postApplicationBranchHandler(anonymous: boolean): (request: express.Req
 					};
 				}
 				else {
-					errored = true;
-					response.status(400).json({
-						"error": `"${question.label}" is a required field`
-					});
-					return null;
+					return reportError(`"${question.label}" is a required field`);
 				}
 			}
-			if ((question.type === "select" || question.type === "radio") && Array.isArray(request.body[question.name]) && question.hasOther) {
+			if (question.minCharacterCount && getQuestion("").length < question.minCharacterCount) {
+				return reportError(`Your response to "${question.label}" must have at least ${question.minCharacterCount} characters`);
+			}
+			if (question.maxCharacterCount && getQuestion("").length > question.maxCharacterCount) {
+				return reportError(`Your response to "${question.label}" cannot exceed ${question.maxCharacterCount} characters`);
+			}
+
+			if ((question.type === "select" || question.type === "radio") && Array.isArray(getQuestion<unknown>(question.name)) && question.hasOther) {
 				// "Other" option selected
-				request.body[question.name] = request.body[question.name].pop();
+				request.body[question.name] = getQuestion<unknown[]>().pop();
 			}
 			else if (question.type === "checkbox" && question.hasOther) {
-				if (!request.body[question.name]) {
+				if (!getQuestion<unknown>(question.name)) {
 					request.body[question.name] = [];
 				}
-				if (!Array.isArray(request.body[question.name])) {
-					request.body[question.name] = [request.body[question.name]];
+				if (!Array.isArray(getQuestion<unknown>(question.name))) {
+					request.body[question.name] = [getQuestion<unknown>()];
 				}
 				// Filter out "other" option
-				request.body[question.name] = (request.body[question.name] as string[]).filter(value => value !== "Other");
+				request.body[question.name] = getQuestion<string[]>().filter(value => value !== "Other");
 			}
 			return {
 				"name": question.name,
 				"type": question.type,
-				"value": request.body[question.name] || files.find(file => file.fieldname === question.name)
+				"value": getQuestion<any>(files.find(file => file.fieldname === question.name))
 			};
 		});
 		if (errored) {

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -158,22 +158,25 @@ function postApplicationBranchHandler(anonymous: boolean): (request: express.Req
 					return reportError(`"${question.label}" is a required field`);
 				}
 			}
-			if (question.minCharacterCount && getQuestion("").length < question.minCharacterCount) {
-				return reportError(`Your response to "${question.label}" must have at least ${question.minCharacterCount} characters`);
-			}
-			if (question.maxCharacterCount && getQuestion("").length > question.maxCharacterCount) {
-				return reportError(`Your response to "${question.label}" cannot exceed ${question.maxCharacterCount} characters`);
-			}
-			let wordCount = getQuestion("").trim().split(/\s+/).length;
-			if (getQuestion("").trim().length === 0) {
-				wordCount = 0;
-			}
-			const wordCountPlural = wordCount === 1 ? "" : "s";
-			if (question.minWordCount && wordCount < question.minWordCount) {
-				return reportError(`Your response to "${question.label}" must contain at least ${question.minWordCount} words (currently has ${wordCount} word${wordCountPlural})`);
-			}
-			if (question.maxWordCount && wordCount > question.maxWordCount) {
-				return reportError(`Your response to "${question.label}" cannot exceed ${question.maxWordCount} words (currently has ${wordCount} word${wordCountPlural})`);
+			if (question.type !== "file" && (question.minCharacterCount || question.maxCharacterCount || question.minWordCount || question.maxWordCount)) {
+				let questionValue = getQuestion<string>("");
+				if (question.minCharacterCount && questionValue.length < question.minCharacterCount) {
+					return reportError(`Your response to "${question.label}" must have at least ${question.minCharacterCount} characters`);
+				}
+				if (question.maxCharacterCount && questionValue.length > question.maxCharacterCount) {
+					return reportError(`Your response to "${question.label}" cannot exceed ${question.maxCharacterCount} characters`);
+				}
+				let wordCount = questionValue.trim().split(/\s+/).length;
+				if (questionValue.trim().length === 0) {
+					wordCount = 0;
+				}
+				const wordCountPlural = wordCount === 1 ? "" : "s";
+				if (question.minWordCount && wordCount < question.minWordCount) {
+					return reportError(`Your response to "${question.label}" must contain at least ${question.minWordCount} words (currently has ${wordCount} word${wordCountPlural})`);
+				}
+				if (question.maxWordCount && wordCount > question.maxWordCount) {
+					return reportError(`Your response to "${question.label}" cannot exceed ${question.maxWordCount} words (currently has ${wordCount} word${wordCountPlural})`);
+				}
 			}
 
 			if ((question.type === "select" || question.type === "radio") && Array.isArray(getQuestion<unknown>(question.name)) && question.hasOther) {

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -128,7 +128,7 @@ function postApplicationBranchHandler(anonymous: boolean): (request: express.Req
 			}
 			function getQuestion<T>(defaultValue?: T): T {
 				let value = request.body[question.name] as T;
-				if (defaultValue) {
+				if (defaultValue !== undefined) {
 					return value || defaultValue;
 				}
 				return value;

--- a/server/routes/api/user.ts
+++ b/server/routes/api/user.ts
@@ -168,7 +168,7 @@ function postApplicationBranchHandler(anonymous: boolean): (request: express.Req
 			if (getQuestion("").trim().length === 0) {
 				wordCount = 0;
 			}
-			let wordCountPlural = wordCount === 1 ? "" : "s";
+			const wordCountPlural = wordCount === 1 ? "" : "s";
 			if (question.minWordCount && wordCount < question.minWordCount) {
 				return reportError(`Your response to "${question.label}" must contain at least ${question.minWordCount} words (currently has ${wordCount} word${wordCountPlural})`);
 			}


### PR DESCRIPTION
* Admins can now add `maxWordCount`, `minWordCount`, `maxCharacterCount`, and `minCharacterCount` to fields that accept text
* Character counts use HTML5 form validation for better user experience (and won't allow sending of form until it passes)
* Word counts are represented live to the user as they type
* Word and character counts are checked server side to prevent sneaky users / crappy browsers from allowing bad inputs
* Word and character counts are stackable (can configure multiple limits for the same question)

Closes #268 