### PR TITLE
Fix log out crashes, clarify teams page

### DIFF
--- a/client/team.html
+++ b/client/team.html
@@ -59,7 +59,7 @@
 					</div>
 				{{else}}
 					<h3>Let's get you in a team!</h3>
-					<p class="align-center">Teams can have up to <strong>{{settings.maxTeamSize}}</strong> members. Teams are optional and you can form them at the event too!</p>
+					<p class="align-center">Teams can have up to <strong>{{settings.maxTeamSize}}</strong> members. If you don't currently have a team, you can form one at the event!</p>
 
 					<div class="row">
 						<div class="col">

--- a/client/team.html
+++ b/client/team.html
@@ -18,6 +18,9 @@
 				margin-top: 0;
 				text-align: center;
 			}
+			.align-center {
+				text-align: center;
+			}
 		</style>
 		<script src="/node_modules/whatwg-fetch/fetch.js"></script>
 		<script src="/node_modules/sweetalert2/dist/sweetalert2.min.js"></script>
@@ -30,6 +33,7 @@
 			<section class="main">
 				{{#if user.teamId}}
 					<h3>Team <b class="teamName">{{team.teamName}}</b></h3>
+					<p class="align-center">Teams can have up to <strong>{{settings.maxTeamSize}}</strong> members.</p>
 					<ul>
 						<li><b>{{teamLeaderAsUser.name}}</b> ({{teamLeaderAsUser.email}}) &mdash; <strong>Team Leader</strong></li>
 						{{#each membersAsUsers}}
@@ -55,6 +59,7 @@
 					</div>
 				{{else}}
 					<h3>Let's get you in a team!</h3>
+					<p class="align-center">Teams can have up to <strong>{{settings.maxTeamSize}}</strong> members. Teams are optional and you can form them at the event too!</p>
 
 					<div class="row">
 						<div class="col">

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "bash ./build.sh",
     "quickbuild": "./node_modules/typescript/bin/tsc -p server/ && ./node_modules/typescript/bin/tsc -p client/",
     "start": "node server/app.js",
-    "build-start": "npm run build && npm start"
+    "build-start": "npm run build && npm start",
+    "debug": "node --nolazy --inspect=9230 server/app.js"
   },
   "author": {
     "name": "Ryan Petschek",

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -59,7 +59,14 @@ authRoutes.all("/logout", async (request, response) => {
 	if (user) {
 		let groundTruthURL = new URL(config.secrets.groundTruth.url);
 		// Invalidates token and logs user out of Ground Truth too
-		await GroundTruthStrategy.apiRequest("POST", new URL("/api/user/logout", groundTruthURL).toString(), user.token || "");
+		try {
+			await GroundTruthStrategy.apiRequest("POST", new URL("/api/user/logout", groundTruthURL).toString(), user.token || "");
+		}
+		catch (err) {
+			// User might already be logged out of Ground Truth
+			// Log them out of registration and continue
+			console.error(err);
+		}
 		request.logout();
 	}
 	if (request.session) {

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -374,7 +374,8 @@ templateRoutes.route("/team").get(authenticateWithRedirect, async (request, resp
 		isCurrentUserTeamLeader,
 		settings: {
 			teamsEnabled: await getSetting<boolean>("teamsEnabled"),
-			qrEnabled: await getSetting<boolean>("qrEnabled")
+			qrEnabled: await getSetting<boolean>("qrEnabled"),
+			maxTeamSize: config.maxTeamSize
 		}
 	};
 	response.send(TeamTemplate.render(templateData));

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -238,6 +238,7 @@ export interface ICommonTemplate {
 	settings: {
 		teamsEnabled: boolean;
 		qrEnabled: boolean;
+		maxTeamSize?: number;
 	};
 }
 type TimelineClass = "" | "complete" | "warning" | "rejected";


### PR DESCRIPTION
* Fix registration crash when user has invalid or expired Ground Truth token 
* Display max team size on teams page
* Clarify that teams are optional on teams page

Fixes #281 
Fixes #282 